### PR TITLE
Update configuration & add types for API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ const Permanent = require('@permanentorg/node-sdk').Permanent;
 const permanent = new Permanent({
   sessionToken,
   mfaToken,
-  archiveId,
+  archiveNbr,
+  apiKey,
+  baseUrl, // optional, defaults to production environment URL
 });
 
 // Ready to use!

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -23,7 +23,7 @@ export class ApiService {
     sessionToken: string,
     mfaToken: string,
     private apiKey: string,
-    baseUrl = 'https://permanent.org/api'
+    baseUrl = 'https://www.permanent.org/api'
   ) {
     this.axiosInstance.defaults.headers = createDefaultHeaders(
       sessionToken,

--- a/src/lib/api/base.repo.spec.ts
+++ b/src/lib/api/base.repo.spec.ts
@@ -2,7 +2,7 @@ import anyTest, { TestInterface } from 'ava';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
-import { PermanentApiData } from '../model';
+import { PermanentApiRequestData } from '../model';
 
 import { BaseRepo, PermanentApiRequest } from './base.repo';
 import { CsrfStore } from './csrf';
@@ -73,7 +73,9 @@ test('CsrfStore is updated with csrf from response', async (t) => {
 });
 
 test('requests are made with provided data', async (t) => {
-  const data: PermanentApiData[] = [{ FolderVO: null }];
+  const data: PermanentApiRequestData[] = [
+    { FolderVO: { folderId: 1, folder_linkId: 2 } },
+  ];
   const endpoint = '/endpoint';
 
   t.context.mockAxios.onPost(`${baseUrl}${endpoint}`).replyOnce((config) => {

--- a/src/lib/api/base.repo.ts
+++ b/src/lib/api/base.repo.ts
@@ -1,6 +1,10 @@
 import { AxiosInstance } from 'axios';
 
-import { PermanentApiData, RequestVO } from '../model';
+import {
+  PermanentApiRequestData,
+  PermanentApiResponseDataBase,
+  RequestVO,
+} from '../model';
 
 import { CsrfStore } from './csrf';
 
@@ -8,14 +12,13 @@ export interface PermanentApiRequest {
   RequestVO: RequestVO;
 }
 
-export interface PermanentApiResponse {
+export interface PermanentApiResponse<T = PermanentApiResponseDataBase> {
   isSuccessful: boolean;
   isSystemUp: boolean;
-  Results: { data: PermanentApiData[] }[];
+  Results: { data: T[]; message?: string[] }[];
   csrf: string;
   sessionId?: string;
 }
-
 export interface RepoConstructorConfig {
   csrfStore: CsrfStore;
   axiosInstance: AxiosInstance;
@@ -33,18 +36,26 @@ export class BaseRepo {
     this.apiKey = config.apiKey;
   }
 
-  async request(
+  async request<
+    T extends PermanentApiResponseDataBase = PermanentApiResponseDataBase
+  >(
     endpoint: string,
-    data: PermanentApiData[] = [{}]
-  ): Promise<PermanentApiResponse> {
-    const requestData: PermanentApiRequest = {
+    data: PermanentApiRequestData[] = [{}]
+  ): Promise<PermanentApiResponse<T>> {
+    const requestBody: PermanentApiRequest = {
       RequestVO: {
-        data,
         apiKey: this.apiKey,
         csrf: this.csrfStore.getCsrf(),
+        data,
       },
     };
-    const response = await this.axiosInstance.post(endpoint, requestData);
+    const response = await this.axiosInstance.post(endpoint, requestBody, {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/plain, */*',
+        'Accept-Encoding': 'gzip, deflate, br',
+      },
+    });
 
     if (response.data.csrf) {
       this.csrfStore.setCsrf(response.data.csrf);

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -1,19 +1,77 @@
-import test from 'ava';
+import anyTest, { TestInterface } from 'ava';
 
 import { Permanent, PermanentConstructorConfigI } from './client';
+import { PermSdkError } from './error';
 
-test('instance gets config options', (t) => {
-  const clientOptions: PermanentConstructorConfigI = {
+const test = anyTest as TestInterface<{
+  permanent: Permanent;
+  options: PermanentConstructorConfigI;
+}>;
+
+test.beforeEach((t) => {
+  const options: PermanentConstructorConfigI = {
     apiKey: 'apiapiapi',
     sessionToken: 'sessionsessionsession',
     mfaToken: 'mfamfamfa',
-    archiveId: 555,
+    archiveNbr: '0001-0000',
   };
+  t.context = {
+    options,
+    permanent: new Permanent(options),
+  };
+});
 
-  const client = new Permanent(clientOptions);
+test('instance gets config options', (t) => {
+  t.truthy(t.context.permanent);
+  t.is(t.context.permanent.getSessionToken(), t.context.options.sessionToken);
+  t.is(t.context.permanent.getMfaToken(), t.context.options.mfaToken);
+  t.is(t.context.permanent.getArchiveNbr(), t.context.options.archiveNbr);
+});
 
-  t.truthy(client);
-  t.is(client.getSessionToken(), clientOptions.sessionToken);
-  t.is(client.getMfaToken(), clientOptions.mfaToken);
-  t.is(client.getArchiveId(), clientOptions.archiveId);
+test('throws error for missing apiKey', async (t) => {
+  const error = t.throws(() => {
+    new Permanent(({
+      ...t.context.options,
+      ...{ apiKey: undefined },
+    } as unknown) as PermanentConstructorConfigI);
+  });
+
+  t.assert(error instanceof PermSdkError);
+  t.assert(error.message.includes('apiKey'));
+});
+
+test('throws error for missing sessionToken', async (t) => {
+  const error = t.throws(() => {
+    new Permanent(({
+      ...t.context.options,
+      ...{ sessionToken: undefined },
+    } as unknown) as PermanentConstructorConfigI);
+  });
+
+  t.assert(error instanceof PermSdkError);
+  t.assert(error.message.includes('sessionToken'));
+});
+
+test('throws error for missing mfaToken', async (t) => {
+  const error = t.throws(() => {
+    new Permanent(({
+      ...t.context.options,
+      ...{ mfaToken: undefined },
+    } as unknown) as PermanentConstructorConfigI);
+  });
+
+  t.assert(error instanceof PermSdkError);
+  t.assert(error.message.includes('mfaToken'));
+});
+
+test('throws error for missing archiveNbr', async (t) => {
+  const error = t.throws(() => {
+    new Permanent(({
+      ...t.context.options,
+      ...{ archiveNbr: undefined },
+    } as unknown) as PermanentConstructorConfigI);
+  });
+
+  t.assert(error instanceof PermSdkError);
+  t.assert(error.message.includes('archiveNbr'));
 });

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,30 +1,48 @@
 import { ApiService } from './api/api.service';
+import { PermSdkError } from './error';
 import { AuthResource } from './resources/auth.resource';
 
 export interface PermanentConstructorConfigI {
   sessionToken: string;
   mfaToken: string;
-  archiveId: number;
+  archiveNbr: string;
   apiKey: string;
+  baseUrl?: string;
 }
 
 export class Permanent {
   private apiKey: string;
   private sessionToken: string;
   private mfaToken: string;
-  private archiveId: number;
+  private archiveNbr: string;
 
-  private api: ApiService;
+  public api: ApiService;
 
   public auth: AuthResource;
   constructor(config: PermanentConstructorConfigI) {
-    const { sessionToken, mfaToken, archiveId, apiKey } = config;
+    const { sessionToken, mfaToken, archiveNbr, apiKey, baseUrl } = config;
+
+    if (!sessionToken) {
+      throw new PermSdkError('Missing sessionToken in config');
+    }
+
+    if (!mfaToken) {
+      throw new PermSdkError('Missing mfaToken in config');
+    }
+
+    if (!archiveNbr) {
+      throw new PermSdkError('Missing archiveNbr in config');
+    }
+
+    if (!apiKey) {
+      throw new PermSdkError('Missing apiKey in config');
+    }
 
     this.sessionToken = sessionToken;
     this.mfaToken = mfaToken;
-    this.archiveId = archiveId;
+    this.archiveNbr = archiveNbr;
     this.apiKey = apiKey;
-    this.api = new ApiService(sessionToken, mfaToken, this.apiKey);
+    this.api = new ApiService(sessionToken, mfaToken, this.apiKey, baseUrl);
     this.auth = new AuthResource(this.api);
   }
 
@@ -36,7 +54,7 @@ export class Permanent {
     return this.mfaToken;
   }
 
-  public getArchiveId() {
-    return this.archiveId;
+  public getArchiveNbr() {
+    return this.archiveNbr;
   }
 }

--- a/src/lib/error.spec.ts
+++ b/src/lib/error.spec.ts
@@ -1,0 +1,26 @@
+import test from 'ava';
+
+import { PermSdkError } from './error';
+
+const packageName = '@permanentorg/node-sdk';
+
+test('should have a generic message with the package name when not given', (t) => {
+  const error = new PermSdkError();
+  t.assert(error.message.includes(packageName));
+});
+
+test('should have the given message prefixed with the package name', (t) => {
+  const message = 'my message';
+  const error = new PermSdkError(message);
+  t.assert(error.message.includes(packageName));
+  t.assert(error.message.includes(message));
+});
+
+test('should have the given message along with API errors, prefixed with the package name', (t) => {
+  const message = 'my message';
+  const apiError = 'error.message';
+  const error = new PermSdkError(message, [apiError]);
+  t.assert(error.message.includes(packageName));
+  t.assert(error.message.includes(message));
+  t.assert(error.message.includes(apiError));
+});

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,15 @@
+export class PermSdkError extends Error {
+  constructor(message?: string, apiMessage?: string[]) {
+    if (!message && !apiMessage) {
+      super(`@permanentorg/node-sdk - error!`);
+    } else if (!apiMessage?.length) {
+      super(`@permanentorg/node-sdk - ${message}`);
+    } else {
+      super(
+        `@permanentorg/node-sdk - ${message} - API message: ${apiMessage.join(
+          ', '
+        )}`
+      );
+    }
+  }
+}

--- a/src/lib/model/account-vo.ts
+++ b/src/lib/model/account-vo.ts
@@ -1,0 +1,5 @@
+import { BaseVO } from './base-vo';
+
+export interface AccountVO extends BaseVO {
+  accountId: number;
+}

--- a/src/lib/model/archive-vo.ts
+++ b/src/lib/model/archive-vo.ts
@@ -1,0 +1,7 @@
+import { BaseVO } from './base-vo';
+
+export interface ArchiveVO extends BaseVO {
+  archiveNbr: string;
+}
+
+export type Archive = ArchiveVO;

--- a/src/lib/model/base-vo.ts
+++ b/src/lib/model/base-vo.ts
@@ -1,0 +1,6 @@
+export interface BaseVO {
+  status?: string;
+  type?: string;
+  createdDT?: string;
+  updatedDT?: string;
+}

--- a/src/lib/model/folder-vo.ts
+++ b/src/lib/model/folder-vo.ts
@@ -1,0 +1,34 @@
+import { BaseVO } from './base-vo';
+
+type FolderType =
+  | 'type.folder.root.app'
+  | 'type.folder.root.private'
+  | 'type.folder.root.public'
+  | 'type.folder.root.share'
+  | 'type.folder.root.vault'
+  | 'type.folder.app'
+  | 'type.folder.private'
+  | 'type.folder.public'
+  | 'type.folder.share'
+  | 'type.folder.vault'
+  | 'page';
+
+export interface FolderVO extends BaseVO {
+  folder_linkId: number;
+  folderId: number;
+  type?: FolderType;
+
+  archiveNbr?: string;
+  archiveId?: number;
+
+  displayName?: string;
+
+  parentFolderId?: number;
+  parentFolder_linkId?: number;
+
+  ChildItemVOs?: FolderVO[];
+}
+
+export type ParentFolderVO = Pick<FolderVO, 'folder_linkId'>;
+
+export type Folder = FolderVO;

--- a/src/lib/model/index.ts
+++ b/src/lib/model/index.ts
@@ -1,1 +1,7 @@
+export * from './account-vo';
+export * from './archive-vo';
+export * from './folder-vo';
+export * from './record-vo';
 export * from './request-vo';
+export * from './share-by-url-vo';
+export * from './simple-vo';

--- a/src/lib/model/record-vo.ts
+++ b/src/lib/model/record-vo.ts
@@ -1,0 +1,23 @@
+import { BaseVO } from './base-vo';
+
+export interface RecordVO extends BaseVO {
+  recordId: number;
+  archiveId: number;
+  archiveNbr: string;
+  displayName: string;
+
+  folder_linkId: number;
+
+  uploadFileName: string;
+  parentFolderId: number;
+  parentFolder_linkId: number;
+}
+
+export type Record = RecordVO;
+
+export interface RecordVOFromUrl
+  extends Pick<RecordVO, 'displayName' | 'uploadFileName'> {
+  parentFolder_linkId: number;
+  uploadUri: string;
+  status: 'status.record.only_meta';
+}

--- a/src/lib/model/request-vo.ts
+++ b/src/lib/model/request-vo.ts
@@ -1,15 +1,34 @@
+import { AccountVO } from './account-vo';
+import { ArchiveVO } from './archive-vo';
+import { FolderVO } from './folder-vo';
+import { RecordVO } from './record-vo';
+import { ShareByUrlVO } from './share-by-url-vo';
 import { SimpleVO } from './simple-vo';
 
-export interface PermanentApiData {
-  FolderVO?: unknown;
-  RecordVO?: unknown;
-  ArchiveVO?: unknown;
-  AccountVO?: unknown;
+export interface PermanentApiResponseDataBase {
+  FolderVO?: FolderVO;
+  RecordVO?: RecordVO;
+  ArchiveVO?: ArchiveVO;
+  AccountVO?: AccountVO;
   SimpleVO?: SimpleVO;
+  Shareby_urlVO?: ShareByUrlVO;
+}
+
+export type PermanentApiResponseData<
+  T extends keyof PermanentApiResponseDataBase
+> = Required<Pick<PermanentApiResponseDataBase, T>>;
+
+export interface PermanentApiRequestData {
+  FolderVO?: Partial<FolderVO>;
+  RecordVO?: Partial<RecordVO>;
+  ArchiveVO?: Partial<ArchiveVO>;
+  AccountVO?: Partial<AccountVO>;
+  SimpleVO?: Partial<SimpleVO>;
+  Shareby_urlVO?: Partial<ShareByUrlVO>;
 }
 
 export interface RequestVO {
   apiKey: string;
   csrf?: string;
-  data: PermanentApiData[];
+  data: PermanentApiRequestData[];
 }

--- a/src/lib/model/share-by-url-vo.ts
+++ b/src/lib/model/share-by-url-vo.ts
@@ -1,0 +1,12 @@
+import { BaseVO } from './base-vo';
+
+export interface ShareByUrlVO extends BaseVO {
+  shareby_urlId: number;
+  folder_linkId: number;
+  shareUrl: string;
+
+  autoApproveToggle: 0 | 1;
+  previewToggle: 0 | 1;
+}
+
+export type ShareLink = ShareByUrlVO;

--- a/src/lib/resources/base.resource.ts
+++ b/src/lib/resources/base.resource.ts
@@ -1,5 +1,18 @@
 import { ApiService } from '../api/api.service';
+import { PermanentApiResponse } from '../api/base.repo';
+import { PermanentApiResponseDataBase } from '../model';
 
 export class BaseResource {
   constructor(public api: ApiService) {}
+
+  getVoFromResponse<T = PermanentApiResponseDataBase>(
+    response: PermanentApiResponse<T>,
+    voName: keyof T
+  ) {
+    return response.Results[0].data[0][voName];
+  }
+
+  getMessageFromResponse(response: PermanentApiResponse) {
+    return response.Results[0].message;
+  }
 }


### PR DESCRIPTION
API responses now support generics that allow you to specify the shape of the expected response and prevent the use of type guards to ensure specific properties exist on a given API response

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Lots of `:?` in the API response interface, which leads to a lot of `undefined` checks that don't need to be there when we know what shape the response really has.

- **What is the new behavior (if this is a feature change)?**
API responses now support generics that allow you to specify the shape of the expected response and prevent the use of type guards to ensure specific properties exist on a given API response. Also some other smaller housekeeping things such as throwing errors for missing config params, and a helper error class to help give useful error messages.

