### PR TITLE
Add async init method to set up client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ const permanent = new Permanent({
   baseUrl, // optional, defaults to production environment URL
 });
 
+// initialize client and session
+await permanent.init();
+
 // Ready to use!
 const isSessionValid = await permanent.auth.isSessionValid();
 ```

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { ArchiveRepo } from './archive.repo';
 
+import { ArchiveRepo } from './archive.repo';
 import { AuthRepo } from './auth.repo';
 import { RepoConstructorConfig } from './base.repo';
 import { CsrfStore } from './csrf';

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { ArchiveRepo } from './archive.repo';
 
 import { AuthRepo } from './auth.repo';
 import { RepoConstructorConfig } from './base.repo';
@@ -17,6 +18,7 @@ export class ApiService {
     apiKey: this.apiKey,
   };
 
+  public archive = new ArchiveRepo(this.repoConfig);
   public auth = new AuthRepo(this.repoConfig);
 
   constructor(

--- a/src/lib/api/archive.repo.spec.ts
+++ b/src/lib/api/archive.repo.spec.ts
@@ -1,0 +1,73 @@
+import anyTest, { TestInterface } from 'ava';
+import axios from 'axios';
+import * as sinon from 'sinon';
+
+import { PermanentApiRequestData } from '../model';
+
+import { ArchiveRepo } from './archive.repo';
+import { CsrfStore } from './csrf';
+
+const test = anyTest as TestInterface<{
+  archiveRepo: ArchiveRepo;
+  csrfStore: CsrfStore;
+}>;
+
+const apiKey = 'apiKey';
+
+test.beforeEach('New ArchiveRepo', (t) => {
+  const csrfStore = new CsrfStore();
+  const axiosInstance = axios.create();
+
+  t.context = {
+    csrfStore,
+    archiveRepo: new ArchiveRepo({
+      csrfStore,
+      axiosInstance,
+      apiKey,
+    }),
+  };
+});
+
+test('should create', (t) => {
+  t.assert(t.context.archiveRepo);
+});
+
+test('should call getByArchiveNbr endpoint with ArchiveVO', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+  const archiveNbr = '0001-0000';
+
+  const expectedRequestData: PermanentApiRequestData[] = [
+    {
+      ArchiveVO: {
+        archiveNbr,
+      },
+    },
+  ];
+
+  sinon.replace(t.context.archiveRepo, 'request', requestFake);
+
+  t.context.archiveRepo.getByArchiveNbr(archiveNbr);
+
+  t.assert(
+    requestFake.calledOnceWith('/archive/getByArchiveNbr', expectedRequestData)
+  );
+});
+
+test('should call change endpoint with ArchiveVO', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+  const archiveNbr = '0001-0000';
+
+  const expectedRequestData: PermanentApiRequestData[] = [
+    {
+      ArchiveVO: {
+        archiveNbr,
+      },
+    },
+  ];
+
+  sinon.replace(t.context.archiveRepo, 'request', requestFake);
+
+  await t.context.archiveRepo.change(archiveNbr);
+
+  t.assert(requestFake.calledOnceWith('/archive/change', expectedRequestData));
+});

--- a/src/lib/api/archive.repo.spec.ts
+++ b/src/lib/api/archive.repo.spec.ts
@@ -12,8 +12,6 @@ const test = anyTest as TestInterface<{
   csrfStore: CsrfStore;
 }>;
 
-const apiKey = 'apiKey';
-
 test.beforeEach('New ArchiveRepo', (t) => {
   const csrfStore = new CsrfStore();
   const axiosInstance = axios.create();
@@ -23,7 +21,7 @@ test.beforeEach('New ArchiveRepo', (t) => {
     archiveRepo: new ArchiveRepo({
       csrfStore,
       axiosInstance,
-      apiKey,
+      apiKey: 'fakeTestApiKey',
     }),
   };
 });

--- a/src/lib/api/archive.repo.ts
+++ b/src/lib/api/archive.repo.ts
@@ -1,0 +1,28 @@
+import { PermanentApiRequestData, PermanentApiResponseData } from '../model';
+
+import { BaseRepo } from './base.repo';
+
+export type ArchiveResponse = PermanentApiResponseData<'ArchiveVO'>;
+
+export class ArchiveRepo extends BaseRepo {
+  public getByArchiveNbr(archiveNbr: string) {
+    const requestData: PermanentApiRequestData = {
+      ArchiveVO: {
+        archiveNbr,
+      },
+    };
+    return this.request<ArchiveResponse>('/archive/getByArchiveNbr', [
+      requestData,
+    ]);
+  }
+
+  public change(archiveNbr: string) {
+    const requestData: PermanentApiRequestData = {
+      ArchiveVO: {
+        archiveNbr,
+      },
+    };
+
+    return this.request<ArchiveResponse>('/archive/change', [requestData]);
+  }
+}

--- a/src/lib/api/auth.repo.spec.ts
+++ b/src/lib/api/auth.repo.spec.ts
@@ -12,7 +12,7 @@ const test = anyTest as TestInterface<{
 
 const apiKey = 'apiKey';
 
-test.beforeEach('New BaseRepo', (t) => {
+test.beforeEach('New AuthRepo', (t) => {
   const csrfStore = new CsrfStore();
   const axiosInstance = axios.create();
 

--- a/src/lib/api/auth.repo.ts
+++ b/src/lib/api/auth.repo.ts
@@ -1,7 +1,11 @@
+import { PermanentApiResponseData } from '../model';
+
 import { BaseRepo } from './base.repo';
+
+export type SimpleVOResponse = PermanentApiResponseData<'SimpleVO'>;
 
 export class AuthRepo extends BaseRepo {
   public isLoggedIn() {
-    return this.request('/auth/loggedIn');
+    return this.request<SimpleVOResponse>('/auth/loggedIn');
   }
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,5 +1,6 @@
 import { ApiService } from './api/api.service';
 import { PermSdkError } from './error';
+import { ArchiveStore } from './resources/archive';
 import { AuthResource } from './resources/auth.resource';
 
 export interface PermanentConstructorConfigI {
@@ -19,6 +20,8 @@ export class Permanent {
   public api: ApiService;
 
   public auth: AuthResource;
+
+  public archiveStore = new ArchiveStore();
   constructor(config: PermanentConstructorConfigI) {
     const { sessionToken, mfaToken, archiveNbr, apiKey, baseUrl } = config;
 
@@ -43,7 +46,7 @@ export class Permanent {
     this.archiveNbr = archiveNbr;
     this.apiKey = apiKey;
     this.api = new ApiService(sessionToken, mfaToken, this.apiKey, baseUrl);
-    this.auth = new AuthResource(this.api);
+    this.auth = new AuthResource(this.api, this.archiveStore);
   }
 
   public getSessionToken() {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,7 +1,7 @@
 import { ApiService } from './api/api.service';
 import { PermSdkError } from './error';
 import { ArchiveStore } from './resources/archive';
-import { AuthResource } from './resources/auth.resource';
+import { SessionResource } from './resources/session.resource';
 
 export interface PermanentConstructorConfigI {
   sessionToken: string;
@@ -19,7 +19,7 @@ export class Permanent {
 
   public api: ApiService;
 
-  public auth: AuthResource;
+  public session: SessionResource;
 
   public archiveStore = new ArchiveStore();
   constructor(config: PermanentConstructorConfigI) {
@@ -46,7 +46,7 @@ export class Permanent {
     this.archiveNbr = archiveNbr;
     this.apiKey = apiKey;
     this.api = new ApiService(sessionToken, mfaToken, this.apiKey, baseUrl);
-    this.auth = new AuthResource(this.api, this.archiveStore);
+    this.session = new SessionResource(this.api, this.archiveStore);
   }
 
   public getSessionToken() {

--- a/src/lib/resources/archive/archive.store.spec.ts
+++ b/src/lib/resources/archive/archive.store.spec.ts
@@ -1,0 +1,59 @@
+import anyTest, { TestInterface } from 'ava';
+
+import { PermSdkError } from '../../error';
+import { FolderVO } from '../../model';
+
+import { ArchiveStore } from '.';
+
+const test = anyTest as TestInterface<{
+  archiveStore: ArchiveStore;
+}>;
+
+test.beforeEach((t) => {
+  t.context = {
+    archiveStore: new ArchiveStore(),
+  };
+});
+
+test('returns the private root folder', (t) => {
+  const root: FolderVO = {
+    folderId: 1,
+    folder_linkId: 1,
+    ChildItemVOs: [
+      {
+        folderId: 2,
+        folder_linkId: 2,
+        type: 'type.folder.root.public',
+      },
+      {
+        folderId: 3,
+        folder_linkId: 3,
+        type: 'type.folder.root.private',
+      },
+      {
+        folderId: 4,
+        folder_linkId: 4,
+        type: 'type.folder.root.share',
+      },
+    ],
+  };
+
+  t.context.archiveStore.setRoot(root);
+
+  const privateRoot = t.context.archiveStore.getPrivateRoot();
+
+  if (root.ChildItemVOs?.length) {
+    t.is(root.ChildItemVOs[1], privateRoot);
+  } else {
+    t.fail();
+  }
+});
+
+test('throws error if getPrivateRoot called before init()', (t) => {
+  const error = t.throws(() => {
+    t.context.archiveStore.getPrivateRoot();
+  });
+
+  t.assert(error.message.includes('init'));
+  t.assert(error instanceof PermSdkError);
+});

--- a/src/lib/resources/archive/index.ts
+++ b/src/lib/resources/archive/index.ts
@@ -1,6 +1,13 @@
 import { PermSdkError } from '../../error';
 import { ArchiveVO, FolderVO } from '../../model';
 
+/**
+ * Used to store data about the current session, such as:
+ * - the current `archive`
+ * - the root `folder` of the current `archive`
+ * 
+ * Certain API calls require base details to be successful. `ArchiveStore` can be used by a `Resource` to store and access this data, which simplifies the experience by keeping the end user from needing to manage and provide it on their own.
+ */
 export class ArchiveStore {
   private archive: ArchiveVO | undefined;
   private root: FolderVO | undefined;

--- a/src/lib/resources/archive/index.ts
+++ b/src/lib/resources/archive/index.ts
@@ -5,7 +5,7 @@ import { ArchiveVO, FolderVO } from '../../model';
  * Used to store data about the current session, such as:
  * - the current `archive`
  * - the root `folder` of the current `archive`
- * 
+ *
  * Certain API calls require base details to be successful. `ArchiveStore` can be used by a `Resource` to store and access this data, which simplifies the experience by keeping the end user from needing to manage and provide it on their own.
  */
 export class ArchiveStore {

--- a/src/lib/resources/archive/index.ts
+++ b/src/lib/resources/archive/index.ts
@@ -1,0 +1,35 @@
+import { PermSdkError } from '../../error';
+import { ArchiveVO, FolderVO } from '../../model';
+
+export class ArchiveStore {
+  private archive: ArchiveVO | undefined;
+  private root: FolderVO | undefined;
+
+  setArchive(archive: ArchiveVO) {
+    this.archive = archive;
+  }
+
+  getArchive() {
+    return this.archive;
+  }
+
+  setRoot(root: FolderVO) {
+    this.root = root;
+  }
+
+  getRoot() {
+    return this.root;
+  }
+
+  getPrivateRoot() {
+    if (!this.root || !this.root.ChildItemVOs) {
+      throw new PermSdkError('call init() before use');
+    }
+
+    const [privateRoot] = this.root.ChildItemVOs.filter(
+      (f) => f.type === 'type.folder.root.private'
+    );
+
+    return privateRoot;
+  }
+}

--- a/src/lib/resources/auth.resource.spec.ts
+++ b/src/lib/resources/auth.resource.spec.ts
@@ -3,20 +3,29 @@ import * as sinon from 'sinon';
 
 import { ApiService } from '../api/api.service';
 import { PermanentApiResponse } from '../api/base.repo';
+import { PermSdkError } from '../error';
 
+import { ArchiveStore } from './archive';
 import { AuthResource } from './auth.resource';
 
 const test = anyTest as TestInterface<{
   auth: AuthResource;
   api: ApiService;
+  archiveStore: ArchiveStore;
 }>;
 
 test.beforeEach((t) => {
   const api = new ApiService('session', 'mfa', 'test');
+  const archiveStore = new ArchiveStore();
   t.context = {
     api,
-    auth: new AuthResource(api),
+    archiveStore,
+    auth: new AuthResource(api, archiveStore),
   };
+});
+
+test('should create', (t) => {
+  t.assert(t.context.auth);
 });
 
 test('returns true for valid session', async (t) => {
@@ -97,4 +106,70 @@ test('returns false for errored request', async (t) => {
   const isLoggedIn = await t.context.auth.isSessionValid();
 
   t.assert(!isLoggedIn);
+});
+
+test('set archive in ArchiveStore after successful archive change request', async (t) => {
+  sinon.replace(t.context.auth, 'isSessionValid', sinon.fake.resolves(true));
+
+  const archiveNbr = '0003-0000';
+
+  const changeArchiveResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            ArchiveVO: {
+              archiveNbr,
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const changeArchiveResponseFake = sinon.fake.resolves(changeArchiveResponse);
+  sinon.replace(t.context.api.archive, 'change', changeArchiveResponseFake);
+
+  await t.context.auth.useArchive(archiveNbr);
+
+  t.is(t.context.archiveStore.getArchive()?.archiveNbr, archiveNbr);
+});
+
+test('throw error on change if credentials invalid', async (t) => {
+  sinon.replace(t.context.auth, 'isSessionValid', sinon.fake.resolves(false));
+
+  const archiveNbr = '0003-0000';
+  const error = await t.throwsAsync(t.context.auth.useArchive(archiveNbr));
+  t.assert(error instanceof PermSdkError);
+});
+
+test('throw error on change if failed request', async (t) => {
+  sinon.replace(t.context.auth, 'isSessionValid', sinon.fake.resolves(true));
+
+  const archiveNbr = '0003-0000';
+  const changeArchiveResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: false,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            ArchiveVO: {
+              archiveNbr,
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const responseFake = sinon.fake.resolves(changeArchiveResponse);
+  sinon.replace(t.context.api.archive, 'change', responseFake);
+
+  const error = await t.throwsAsync(t.context.auth.useArchive(archiveNbr));
+  t.assert(error.message.includes(archiveNbr));
 });

--- a/src/lib/resources/auth.resource.ts
+++ b/src/lib/resources/auth.resource.ts
@@ -6,7 +6,7 @@ import { ArchiveStore } from './archive';
 import { BaseResource } from './base.resource';
 /**
  * `Resource` that manages any exposed auth and session state methods for the client instance.
- * 
+ *
  * This includes things such as:
  * - validating the credentials and session
  * - setting which archive is currently in use by the client instance

--- a/src/lib/resources/auth.resource.ts
+++ b/src/lib/resources/auth.resource.ts
@@ -4,7 +4,13 @@ import { PermSdkError } from '../error';
 
 import { ArchiveStore } from './archive';
 import { BaseResource } from './base.resource';
-
+/**
+ * `Resource` that manages any exposed auth and session state methods for the client instance.
+ * 
+ * This includes things such as:
+ * - validating the credentials and session
+ * - setting which archive is currently in use by the client instance
+ */
 export class AuthResource extends BaseResource {
   constructor(public api: ApiService, public archiveStore: ArchiveStore) {
     super(api, archiveStore);

--- a/src/lib/resources/base.resource.ts
+++ b/src/lib/resources/base.resource.ts
@@ -4,6 +4,14 @@ import { PermanentApiResponseDataBase } from '../model';
 
 import { ArchiveStore } from './archive';
 
+/**
+ * Base `Resource` to be extended by other feature/functional `Resources`
+ * 
+ * A `Resource` is the main organizational unit exposed to the end user, containing all methods pertaining to a specific feature, such as folders or sharing.
+ * 
+ * It optionally has access to shared session state stored in `ArchiveStore`, to automatically manage any boilerplate details required for a given task.
+ *
+ */
 export class BaseResource {
   constructor(public api: ApiService, public archiveStore?: ArchiveStore) {}
 

--- a/src/lib/resources/base.resource.ts
+++ b/src/lib/resources/base.resource.ts
@@ -2,8 +2,10 @@ import { ApiService } from '../api/api.service';
 import { PermanentApiResponse } from '../api/base.repo';
 import { PermanentApiResponseDataBase } from '../model';
 
+import { ArchiveStore } from './archive';
+
 export class BaseResource {
-  constructor(public api: ApiService) {}
+  constructor(public api: ApiService, public archiveStore?: ArchiveStore) {}
 
   getVoFromResponse<T = PermanentApiResponseDataBase>(
     response: PermanentApiResponse<T>,

--- a/src/lib/resources/base.resource.ts
+++ b/src/lib/resources/base.resource.ts
@@ -6,9 +6,9 @@ import { ArchiveStore } from './archive';
 
 /**
  * Base `Resource` to be extended by other feature/functional `Resources`
- * 
+ *
  * A `Resource` is the main organizational unit exposed to the end user, containing all methods pertaining to a specific feature, such as folders or sharing.
- * 
+ *
  * It optionally has access to shared session state stored in `ArchiveStore`, to automatically manage any boilerplate details required for a given task.
  *
  */

--- a/src/lib/resources/session.resource.ts
+++ b/src/lib/resources/session.resource.ts
@@ -11,7 +11,7 @@ import { BaseResource } from './base.resource';
  * - validating the credentials and session
  * - setting which archive is currently in use by the client instance
  */
-export class AuthResource extends BaseResource {
+export class SessionResource extends BaseResource {
   constructor(public api: ApiService, public archiveStore: ArchiveStore) {
     super(api, archiveStore);
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature
- **What is the current behavior?** (You can also link to an open issue here)
No `init` method, the client doesn't require any setup (as it has no real methods ;) ) beyond credentials

- **What is the new behavior (if this is a feature change)?**
Adds an `init` method that the user must call before proceeding. The `init` method is required to actually prepare the client to useful things in the session, rather than just validate that the session exists. AuthResource requires ArchiveRepo endpoints to switch to the archive provided in the client config.