### PR TITLE
Add share

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,47 @@ const newFolder = await permanent.folder.create(
   existingFolder // optional, specify to create somewhere besides My Files folder
 );
 ```
+
+### Generating share links
+
+To create a public share link that can be used to request sharing access to an item, use either `share.createRecordShareLink` or `share.createFolderShareLink` to share either a single `record` or a single `folder`, respectively.
+
+The share link defaults to allowing preview of items without having access, and auto-approving access for anyone who requests it, but these options can be specified using optional parameters.
+
+```js
+// Upload and share a single record with default settings
+
+const record = await permanent.record.uploadFromUrl({
+  /* record data */
+});
+const recordShareUrl = await permanent.share.createRecordShareLink(record);
+
+// Create and share a folder with preview and auto-approve disabled
+
+const folder = await permanent.folder.create('Shared Photos');
+await permanent.record.uploadFromUrl(
+  {
+    /* record data */
+  },
+  folder
+);
+const folderShareUrl = await permanent.share.createFolderShareLink(
+  folder,
+  false,
+  false
+);
+```
+
+There's also an optional parameter available when creating share links that allows setting the default access level given to archives granted access to the share. An `AccessRole` enum has been exported with all access role values.
+
+```js
+import { Permanent, AccessRole } from '@permanentorg/node-sdk';
+
+const folderShareUrl = await permanent.share.createFolderShareLink(
+  folder,
+  false,
+  false,
+  AccessRole.Curator
+);
+```
+

--- a/examples/share.js
+++ b/examples/share.js
@@ -1,0 +1,41 @@
+// To run this script, use `node share.js`
+//
+// Uncomment this line to run on an insecure local environment, if you
+// like:
+// process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const permSdk = require('@permanentorg/node-sdk');
+
+// You can pull the "permSession" and "permMFA" cookie values from
+// devtools on any request.  Include
+//
+// 'baseUrl': 'https://local.permanent.org/api'
+//
+// or similar if you want to run this locally or on another
+// environment (by default it will run against prod)
+
+const permanent = new permSdk.Permanent({
+    'sessionToken': 'permSession_COOKIE',
+    'mfaToken': 'permMFA_COOKIE',
+    'archiveNbr': 'YOUR_ARCHIVE',
+    'apiKey': 'PERMANENT_API_KEY',
+});
+
+run();
+
+async function run() {
+    await permanent.init();
+    console.log('session started');
+
+    const newFolder = await permanent.folder.create(`share test @ ${new Date().toISOString()}`);
+    console.log('folder created');
+
+    const folderShareUrl = await permanent.share.createFolderShareLink(
+      newFolder,
+      false,
+      false
+    );
+
+    console.log('Folder share link is:');
+    console.log(folderShareUrl);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { Permanent } from './lib/client';
+export { AccessRole } from './lib/enum/access-role';

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -6,6 +6,7 @@ import { RepoConstructorConfig } from './base.repo';
 import { CsrfStore } from './csrf';
 import { FolderRepo } from './folder.repo';
 import { RecordRepo } from './record.repo';
+import { ShareRepo } from './share.repo';
 
 export const SESSION_COOKIE = 'permSession';
 export const MFA_COOKIE = 'permMFA';
@@ -24,6 +25,7 @@ export class ApiService {
   public auth = new AuthRepo(this.repoConfig);
   public folder = new FolderRepo(this.repoConfig);
   public record = new RecordRepo(this.repoConfig);
+  public share = new ShareRepo(this.repoConfig);
 
   constructor(
     sessionToken: string,

--- a/src/lib/api/share.repo.spec.ts
+++ b/src/lib/api/share.repo.spec.ts
@@ -1,0 +1,98 @@
+import anyTest, { TestInterface } from 'ava';
+import axios from 'axios';
+import * as sinon from 'sinon';
+
+import {
+  FolderVO,
+  PermanentApiRequestData,
+  RecordVO,
+  ShareByUrlVO,
+} from '../model';
+
+import { CsrfStore } from './csrf';
+import { ShareRepo } from './share.repo';
+
+const test = anyTest as TestInterface<{
+  shareRepo: ShareRepo;
+  csrfStore: CsrfStore;
+}>;
+
+const apiKey = 'apiKey';
+
+test.beforeEach('New ShareRepo', (t) => {
+  const csrfStore = new CsrfStore();
+  const axiosInstance = axios.create();
+
+  t.context = {
+    csrfStore,
+    shareRepo: new ShareRepo({
+      csrfStore,
+      axiosInstance,
+      apiKey,
+    }),
+  };
+});
+
+test('should create', (t) => {
+  t.assert(t.context.shareRepo);
+});
+
+test('should call generateShareLink with proper data for record', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+  const recordToShare: Pick<RecordVO, 'folder_linkId'> = { folder_linkId: 1 };
+
+  const expectedRequestData: PermanentApiRequestData[] = [
+    {
+      RecordVO: recordToShare,
+    },
+  ];
+  sinon.replace(t.context.shareRepo, 'request', requestFake);
+
+  await t.context.shareRepo.generateRecordShareLink(recordToShare);
+
+  t.assert(
+    requestFake.calledOnceWith('/share/generateShareLink', expectedRequestData)
+  );
+});
+
+test('should call generateShareLink with proper data for folder', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+  const folderToShare: Pick<FolderVO, 'folder_linkId'> = { folder_linkId: 1 };
+
+  const expectedRequestData: PermanentApiRequestData[] = [
+    {
+      FolderVO: folderToShare,
+    },
+  ];
+  sinon.replace(t.context.shareRepo, 'request', requestFake);
+
+  await t.context.shareRepo.generateFolderShareLink(folderToShare);
+
+  t.assert(
+    requestFake.calledOnceWith('/share/generateShareLink', expectedRequestData)
+  );
+});
+
+test('should call updateShareLink with proper data for ShareByUrlVO', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+  const shareByUrlVo: ShareByUrlVO = {
+    shareby_urlId: 1,
+    shareUrl: 'url',
+    folder_linkId: 5,
+    autoApproveToggle: 0,
+    previewToggle: 1,
+  };
+
+  const expectedRequestData: PermanentApiRequestData[] = [
+    {
+      Shareby_urlVO: shareByUrlVo,
+    },
+  ];
+  sinon.replace(t.context.shareRepo, 'request', requestFake);
+
+  await t.context.shareRepo.updateShareLink(shareByUrlVo);
+
+  t.assert(
+    requestFake.calledOnceWith('/share/updateShareLink', expectedRequestData)
+  );
+});

--- a/src/lib/api/share.repo.ts
+++ b/src/lib/api/share.repo.ts
@@ -1,0 +1,43 @@
+import {
+  FolderVO,
+  PermanentApiRequestData,
+  PermanentApiResponseData,
+  RecordVO,
+  ShareByUrlVO,
+} from '../model';
+
+import { BaseRepo } from './base.repo';
+
+export type ShareByUrlResponse = PermanentApiResponseData<'Shareby_urlVO'>;
+
+export class ShareRepo extends BaseRepo {
+  public generateRecordShareLink(record: Pick<RecordVO, 'folder_linkId'>) {
+    const requestData: PermanentApiRequestData = {
+      RecordVO: record,
+    };
+
+    return this.request<ShareByUrlResponse>('/share/generateShareLink', [
+      requestData,
+    ]);
+  }
+
+  public generateFolderShareLink(folder: Pick<FolderVO, 'folder_linkId'>) {
+    const requestData: PermanentApiRequestData = {
+      FolderVO: folder,
+    };
+
+    return this.request<ShareByUrlResponse>('/share/generateShareLink', [
+      requestData,
+    ]);
+  }
+
+  public updateShareLink(shareByUrl: ShareByUrlVO) {
+    const requestData: PermanentApiRequestData = {
+      Shareby_urlVO: shareByUrl,
+    };
+
+    return this.request<ShareByUrlResponse>('/share/updateShareLink', [
+      requestData,
+    ]);
+  }
+}

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -4,6 +4,7 @@ import { ArchiveStore } from './resources/archive';
 import { FolderResource } from './resources/folder.resource';
 import { RecordResource } from './resources/record.resource';
 import { SessionResource } from './resources/session.resource';
+import { ShareResource } from './resources/share.resource';
 
 export interface PermanentConstructorConfigI {
   sessionToken: string;
@@ -24,6 +25,7 @@ export class Permanent {
   public folder: FolderResource;
   public record: RecordResource;
   public session: SessionResource;
+  public share: ShareResource;
 
   public archiveStore = new ArchiveStore();
   constructor(config: PermanentConstructorConfigI) {
@@ -53,6 +55,7 @@ export class Permanent {
     this.folder = new FolderResource(this.api, this.archiveStore);
     this.record = new RecordResource(this.api, this.archiveStore);
     this.session = new SessionResource(this.api, this.archiveStore);
+    this.share = new ShareResource(this.api);
   }
 
   public async init() {

--- a/src/lib/enum/access-role.ts
+++ b/src/lib/enum/access-role.ts
@@ -1,0 +1,7 @@
+export enum AccessRole {
+  Viewer = 'access.role.viewer',
+  Contributor = 'access.role.contributor',
+  Editor = 'access.role.editor',
+  Curator = 'access.role.curator',
+  Owner = 'access.role.owner',
+}

--- a/src/lib/model/share-by-url-vo.ts
+++ b/src/lib/model/share-by-url-vo.ts
@@ -1,3 +1,5 @@
+import { AccessRole } from '../enum/access-role';
+
 import { BaseVO } from './base-vo';
 
 export interface ShareByUrlVO extends BaseVO {
@@ -7,6 +9,7 @@ export interface ShareByUrlVO extends BaseVO {
 
   autoApproveToggle: 0 | 1;
   previewToggle: 0 | 1;
+  defaultAccessRole?: AccessRole;
 }
 
 export type ShareLink = ShareByUrlVO;

--- a/src/lib/resources/share.resource.spec.ts
+++ b/src/lib/resources/share.resource.spec.ts
@@ -1,0 +1,311 @@
+import anyTest, { TestInterface } from 'ava';
+import * as sinon from 'sinon';
+
+import { ApiService } from '../api/api.service';
+import { PermanentApiResponse } from '../api/base.repo';
+import { AccessRole } from '../enum/access-role';
+import { PermSdkError } from '../error';
+import { ShareByUrlVO } from '../model';
+
+import { ShareResource } from './share.resource';
+
+const test = anyTest as TestInterface<{
+  share: ShareResource;
+  api: ApiService;
+}>;
+
+test.beforeEach((t) => {
+  const api = new ApiService('session', 'mfa', 'test');
+  t.context = {
+    api,
+    share: new ShareResource(api),
+  };
+});
+
+test('should create', (t) => {
+  t.assert(t.context.share);
+});
+
+test('should return the new share URL on successful record share link response', async (t) => {
+  const expectedShareUrl = 'https://share.com';
+  const folder_linkId = 1;
+
+  const vo: ShareByUrlVO = {
+    shareUrl: expectedShareUrl,
+    shareby_urlId: 1,
+    folder_linkId,
+    autoApproveToggle: 0,
+    previewToggle: 0,
+    defaultAccessRole: AccessRole.Viewer,
+  };
+
+  const fakeResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            Shareby_urlVO: vo,
+          },
+        ],
+      },
+    ],
+  };
+  const responseFake = sinon.fake.resolves(fakeResponse);
+  sinon.replace(t.context.api.share, 'generateRecordShareLink', responseFake);
+
+  const updateFake = sinon.fake.resolves(true);
+  sinon.replace(t.context.share, 'updateShareLink', updateFake);
+
+  const shareUrl = await t.context.share.createRecordShareLink({
+    folder_linkId,
+  });
+
+  t.assert(updateFake.calledOnceWith(vo, true, true));
+  t.is(shareUrl, expectedShareUrl);
+});
+
+test('should not update record share link preview and auto approve if set to false', async (t) => {
+  const expectedShareUrl = 'https://share.com';
+  const folder_linkId = 1;
+
+  const fakeResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            Shareby_urlVO: {
+              shareUrl: expectedShareUrl,
+              shareby_urlId: 1,
+              folder_linkId,
+              autoApproveToggle: 0,
+              previewToggle: 0,
+              defaultAccessRole: AccessRole.Viewer,
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const responseFake = sinon.fake.resolves(fakeResponse);
+  sinon.replace(t.context.api.share, 'generateRecordShareLink', responseFake);
+
+  const updateFake = sinon.fake.resolves(true);
+  sinon.replace(t.context.api.share, 'updateShareLink', updateFake);
+
+  const shareUrl = await t.context.share.createRecordShareLink(
+    {
+      folder_linkId,
+    },
+    false,
+    false
+  );
+
+  t.assert(updateFake.notCalled);
+  t.is(shareUrl, expectedShareUrl);
+});
+
+test('should throw error on unsuccessful record share link response', async (t) => {
+  const folder_linkId = 1;
+  const errorMessage = 'error.message';
+
+  const fakeResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: false,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [],
+        message: [errorMessage],
+      },
+    ],
+  };
+  const responseFake = sinon.fake.resolves(fakeResponse);
+  sinon.replace(t.context.api.share, 'generateRecordShareLink', responseFake);
+
+  const error = await t.throwsAsync(
+    t.context.share.createRecordShareLink({
+      folder_linkId,
+    })
+  );
+
+  t.assert(error instanceof PermSdkError);
+  t.assert(error.message.includes(errorMessage));
+});
+
+test('should return the new share URL on successful folder share link response', async (t) => {
+  const expectedShareUrl = 'https://share.com';
+  const folder_linkId = 1;
+
+  const vo: ShareByUrlVO = {
+    shareUrl: expectedShareUrl,
+    shareby_urlId: 1,
+    folder_linkId,
+    autoApproveToggle: 0,
+    previewToggle: 0,
+  };
+
+  const fakeResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            Shareby_urlVO: vo,
+          },
+        ],
+      },
+    ],
+  };
+  const responseFake = sinon.fake.resolves(fakeResponse);
+  sinon.replace(t.context.api.share, 'generateFolderShareLink', responseFake);
+
+  const updateFake = sinon.fake.resolves(true);
+  sinon.replace(t.context.share, 'updateShareLink', updateFake);
+
+  const shareUrl = await t.context.share.createFolderShareLink({
+    folder_linkId,
+  });
+
+  t.assert(updateFake.calledOnceWith(vo, true, true));
+  t.is(shareUrl, expectedShareUrl);
+});
+
+test('should not update folder share link preview and auto approve if set to false', async (t) => {
+  const expectedShareUrl = 'https://share.com';
+  const folder_linkId = 1;
+
+  const fakeResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            Shareby_urlVO: {
+              shareUrl: expectedShareUrl,
+              shareby_urlId: 1,
+              folder_linkId,
+              autoApproveToggle: 0,
+              previewToggle: 0,
+              defaultAccessRole: AccessRole.Viewer,
+            },
+          },
+        ],
+      },
+    ],
+  };
+  const responseFake = sinon.fake.resolves(fakeResponse);
+  sinon.replace(t.context.api.share, 'generateFolderShareLink', responseFake);
+
+  const updateFake = sinon.fake.resolves(true);
+  sinon.replace(t.context.api.share, 'updateShareLink', updateFake);
+
+  const shareUrl = await t.context.share.createFolderShareLink(
+    {
+      folder_linkId,
+    },
+    false,
+    false
+  );
+
+  t.assert(updateFake.notCalled);
+  t.is(shareUrl, expectedShareUrl);
+});
+
+test('should throw error on unsuccessful folder share link response', async (t) => {
+  const folder_linkId = 1;
+  const errorMessage = 'error.message';
+
+  const fakeResponse: PermanentApiResponse = {
+    csrf: 'csrf',
+    isSuccessful: false,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [],
+        message: [errorMessage],
+      },
+    ],
+  };
+  const responseFake = sinon.fake.resolves(fakeResponse);
+  sinon.replace(t.context.api.share, 'generateFolderShareLink', responseFake);
+
+  const error = await t.throwsAsync(
+    t.context.share.createFolderShareLink({
+      folder_linkId,
+    })
+  );
+
+  t.assert(error instanceof PermSdkError);
+  t.assert(error.message.includes(errorMessage));
+});
+
+test('should set proper values on vo from update share booleans', async (t) => {
+  const defaultVo: ShareByUrlVO = {
+    shareUrl: 'url',
+    shareby_urlId: 1,
+    folder_linkId: 1,
+    autoApproveToggle: 0,
+    previewToggle: 0,
+    defaultAccessRole: AccessRole.Viewer,
+  };
+
+  const firstVo = { ...defaultVo };
+
+  const responseFake = sinon.fake.resolves(true);
+  sinon.replace(t.context.api.share, 'updateShareLink', responseFake);
+
+  await t.context.share.updateShareLink(
+    firstVo,
+    true,
+    true,
+    AccessRole.Curator
+  );
+
+  t.assert(
+    responseFake.calledOnceWith({
+      ...firstVo,
+      autoApproveToggle: 1,
+      previewToggle: 1,
+      defaultAccessRole: AccessRole.Curator,
+    })
+  );
+
+  responseFake.resetHistory();
+
+  const secondVo = { ...defaultVo };
+
+  await t.context.share.updateShareLink(
+    secondVo,
+    false,
+    true,
+    AccessRole.Owner
+  );
+  t.assert(
+    responseFake.calledOnceWith({
+      ...secondVo,
+      autoApproveToggle: 1,
+      previewToggle: 0,
+      defaultAccessRole: AccessRole.Owner,
+    })
+  );
+
+  responseFake.resetHistory();
+  const thirdVo: ShareByUrlVO = {
+    ...defaultVo,
+    previewToggle: 1,
+    autoApproveToggle: 1,
+  };
+
+  await t.context.share.updateShareLink(thirdVo, false, false);
+  t.assert(responseFake.calledOnceWith(thirdVo));
+});

--- a/src/lib/resources/share.resource.ts
+++ b/src/lib/resources/share.resource.ts
@@ -1,0 +1,98 @@
+import { AccessRole } from '../enum/access-role';
+import { PermSdkError } from '../error';
+import { FolderVO, RecordVO, ShareByUrlVO } from '../model';
+
+import { BaseResource } from './base.resource';
+
+export class ShareResource extends BaseResource {
+  async updateShareLink(
+    shareByUrlVo: ShareByUrlVO,
+    showPreview: boolean,
+    autoApprove: boolean,
+    defaultAccessRole?: AccessRole
+  ) {
+    const showPreviewChanged = showPreview
+      ? shareByUrlVo.previewToggle === 0
+      : shareByUrlVo.previewToggle === 1;
+    const autoApproveChanged = autoApprove
+      ? shareByUrlVo.autoApproveToggle === 0
+      : shareByUrlVo.autoApproveToggle === 1;
+    const defaultAccessChanged =
+      defaultAccessRole && defaultAccessRole !== shareByUrlVo.defaultAccessRole;
+
+    if (showPreviewChanged || autoApproveChanged || defaultAccessChanged) {
+      shareByUrlVo.autoApproveToggle = autoApprove ? 1 : 0;
+      shareByUrlVo.previewToggle = showPreview ? 1 : 0;
+      shareByUrlVo.defaultAccessRole = defaultAccessRole;
+
+      await this.api.share.updateShareLink(shareByUrlVo);
+    }
+  }
+
+  /**
+   * Creates a shareable URL for an existing record in the current archive
+   *
+   * #### Example
+   * ```js
+   * const perm = new Permanent(config);
+   *
+   * const record // existing RecordVO
+   * const url = await perm.share.createRecordShareLink(record)
+   * ```
+   * @returns a Promise that resolves to the shareable URL as a string
+   */
+  public async createRecordShareLink(
+    record: Pick<RecordVO, 'folder_linkId'>,
+    showPreview = true,
+    autoApprove = true,
+    defaultAccessRole = AccessRole.Viewer
+  ) {
+    const response = await this.api.share.generateRecordShareLink(record);
+    if (!response.isSuccessful) {
+      throw new PermSdkError(
+        'Record share link creation failed',
+        this.getMessageFromResponse(response)
+      );
+    }
+
+    const vo = this.getVoFromResponse(response, 'Shareby_urlVO');
+
+    await this.updateShareLink(vo, showPreview, autoApprove, defaultAccessRole);
+
+    return vo.shareUrl;
+  }
+
+  /**
+   * Creates a shareable URL for an existing folder in the current archive
+   *
+   * #### Example
+   * ```js
+   * const perm = new Permanent(config);
+   *
+   * const folder // existing FolderVO
+   * const url = await perm.share.createFolderShareLink(folder)
+   * ```
+   *
+   * @returns a Promise that resolves to the shareable URL as a string
+   */
+  public async createFolderShareLink(
+    folder: Pick<FolderVO, 'folder_linkId'>,
+    showPreview = true,
+    autoApprove = true,
+    defaultAccessRole = AccessRole.Viewer
+  ) {
+    const response = await this.api.share.generateFolderShareLink(folder);
+    if (!response.isSuccessful) {
+      throw new PermSdkError(
+        'Folder share link creation failed',
+        this.getMessageFromResponse(response)
+      );
+    }
+
+    const vo = this.getVoFromResponse(response, 'Shareby_urlVO');
+
+    await this.updateShareLink(vo, showPreview, autoApprove, defaultAccessRole);
+
+    return vo.shareUrl;
+  }
+}

--- a/src/lib/resources/share.resource.ts
+++ b/src/lib/resources/share.resource.ts
@@ -5,6 +5,8 @@ import { FolderVO, RecordVO, ShareByUrlVO } from '../model';
 import { BaseResource } from './base.resource';
 
 export class ShareResource extends BaseResource {
+  // note that even though "autoApproveToggle" looks like a boolean,
+  // it is treated as an integer in the backend code.  Hence the zeroes and ones.
   async updateShareLink(
     shareByUrlVo: ShareByUrlVO,
     showPreview: boolean,


### PR DESCRIPTION
This adds the remaining functionality from the `3-upload-item` branch that is currently being used by a partner.  With this change, you can get a share link for a previously created record or folder.  I included a new example script to create a folder and get a share link for it.