### PR TITLE
Add ability to get default archive from session

### DIFF
--- a/src/lib/api/account.repo.ts
+++ b/src/lib/api/account.repo.ts
@@ -1,0 +1,11 @@
+import { PermanentApiResponseData } from '../model';
+
+import { BaseRepo } from './base.repo';
+
+export type AccountVOResponse = PermanentApiResponseData<'AccountVO'>;
+
+export class AccountRepo extends BaseRepo {
+  public getSessionAccount() {
+    return this.request<AccountVOResponse>('/account/getsessionaccount');
+  }
+}

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { AccountRepo } from './account.repo';
 import { ArchiveRepo } from './archive.repo';
 import { AuthRepo } from './auth.repo';
 import { RepoConstructorConfig } from './base.repo';
@@ -21,6 +22,7 @@ export class ApiService {
     apiKey: this.apiKey,
   };
 
+  public account = new AccountRepo(this.repoConfig);
   public archive = new ArchiveRepo(this.repoConfig);
   public auth = new AuthRepo(this.repoConfig);
   public folder = new FolderRepo(this.repoConfig);

--- a/src/lib/api/archive.repo.ts
+++ b/src/lib/api/archive.repo.ts
@@ -16,6 +16,18 @@ export class ArchiveRepo extends BaseRepo {
     ]);
   }
 
+  public getDefaultArchive(archiveId: number) {
+    const requestData: PermanentApiRequestData = {
+      ArchiveVO: {
+        archiveId,
+      },
+    };
+
+    return this.request<ArchiveResponse>('archive/getbyarchiveid', [
+      requestData,
+    ]);
+  }
+
   public change(archiveNbr: string) {
     const requestData: PermanentApiRequestData = {
       ArchiveVO: {

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -63,15 +63,3 @@ test('throws error for missing mfaToken', async (t) => {
   t.assert(error instanceof PermSdkError);
   t.assert(error.message.includes('mfaToken'));
 });
-
-test('throws error for missing archiveNbr', async (t) => {
-  const error = t.throws(() => {
-    new Permanent(({
-      ...t.context.options,
-      ...{ archiveNbr: undefined },
-    } as unknown) as PermanentConstructorConfigI);
-  });
-
-  t.assert(error instanceof PermSdkError);
-  t.assert(error.message.includes('archiveNbr'));
-});

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -9,7 +9,7 @@ import { ShareResource } from './resources/share.resource';
 export interface PermanentConstructorConfigI {
   sessionToken: string;
   mfaToken: string;
-  archiveNbr: string;
+  archiveNbr?: string;
   apiKey: string;
   baseUrl?: string;
 }
@@ -18,7 +18,7 @@ export class Permanent {
   private apiKey: string;
   private sessionToken: string;
   private mfaToken: string;
-  private archiveNbr: string;
+  private archiveNbr?: string;
 
   public api: ApiService;
 
@@ -39,10 +39,6 @@ export class Permanent {
       throw new PermSdkError('Missing mfaToken in config');
     }
 
-    if (!archiveNbr) {
-      throw new PermSdkError('Missing archiveNbr in config');
-    }
-
     if (!apiKey) {
       throw new PermSdkError('Missing apiKey in config');
     }
@@ -59,6 +55,11 @@ export class Permanent {
   }
 
   public async init() {
+    if (this.archiveNbr === undefined) {
+      const archive = await this.session.getAccountArchive();
+      // get the default archiveNbr from the account
+      this.archiveNbr = archive.archiveNbr;
+    }
     await this.session.useArchive(this.archiveNbr);
   }
 

--- a/src/lib/model/account-vo.ts
+++ b/src/lib/model/account-vo.ts
@@ -2,4 +2,5 @@ import { BaseVO } from './base-vo';
 
 export interface AccountVO extends BaseVO {
   accountId: number;
+  defaultArchiveId: number;
 }

--- a/src/lib/model/archive-vo.ts
+++ b/src/lib/model/archive-vo.ts
@@ -2,6 +2,7 @@ import { BaseVO } from './base-vo';
 
 export interface ArchiveVO extends BaseVO {
   archiveNbr: string;
+  archiveId?: number;
 }
 
 export type Archive = ArchiveVO;

--- a/src/lib/resources/session.resource.ts
+++ b/src/lib/resources/session.resource.ts
@@ -2,6 +2,7 @@ import { ApiService } from '../api/api.service';
 import { ArchiveResponse } from '../api/archive.repo';
 import { FolderResponse } from '../api/folder.repo';
 import { PermSdkError } from '../error';
+import { ArchiveVO } from '../model';
 
 import { ArchiveStore } from './archive';
 import { BaseResource } from './base.resource';
@@ -41,6 +42,19 @@ export class SessionResource extends BaseResource {
       }
     } catch (err) {
       return false;
+    }
+  }
+
+  public async getAccountArchive(): Promise<ArchiveVO> {
+    try {
+      const response = await this.api.account.getSessionAccount();
+      const account = response.Results[0].data[0].AccountVO;
+      const archiveResponse = await this.api.archive.getDefaultArchive(
+        account.defaultArchiveId
+      );
+      return archiveResponse.Results[0].data[0].ArchiveVO;
+    } catch (err) {
+      return err;
     }
   }
 


### PR DESCRIPTION
Rather than requiring an archive number when connecting to the SDK, optionally get the default archive for the logged-in user.

@jasonaowen, this actually has two solutions in it: one is simpler and just calls `getRoot`, as we discussed.  That might be the correct thing.  The other gets the account from the session and then the default archive from there.  I'm not sure exactly what you need, I realized as I was doing this, and the `archiveNbr` in the `FolderVO` for the root folder is not the same as the `archiveNbr` in the `archive` table (frustrating).  Anyway, please read this and let me know which parts are useful - do you want the whole default archive or do you really just need the user's root folder?  Depending on which parts you want, there are some corresponding back-end changes which I will link in a comment.

This depends on #17, for simplicity's sake.  I'll rebase on main when that's merged.  In the meantime it's easiest to compare this branch to `add-share`.