### PR TITLE
Remove Permanent API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Built on [bitjson/typescript-starter](https://github.com/bitjson/typescript-star
 
 ## Usage
 
-The client needs to be configured with access keys, available on request from engineers@permanent.org.
+The client needs to be configured with authentication tokens.
+Please contact engineers@permanent.org for access.
 
 ```js
 // ES import
@@ -22,7 +23,6 @@ const permanent = new Permanent({
   sessionToken,
   mfaToken,
   archiveNbr,
-  apiKey,
   baseUrl, // optional, defaults to prod environment URL
 });
 

--- a/examples/share.js
+++ b/examples/share.js
@@ -18,7 +18,6 @@ const permanent = new permSdk.Permanent({
     'sessionToken': 'permSession_COOKIE',
     'mfaToken': 'permMFA_COOKIE',
     'archiveNbr': 'YOUR_ARCHIVE',
-    'apiKey': 'PERMANENT_API_KEY',
 });
 
 run();

--- a/examples/upload.js
+++ b/examples/upload.js
@@ -18,7 +18,6 @@ const permanent = new permSdk.Permanent({
     'sessionToken': 'permSession_COOKIE',
     'mfaToken': 'permMFA_COOKIE',
     'archiveNbr': 'YOUR_ARCHIVE',
-    'apiKey': 'PERMANENT_API_KEY',
 });
 
 const token = 'YOUR_TOKEN_HERE';

--- a/src/lib/api/api.service.spec.ts
+++ b/src/lib/api/api.service.spec.ts
@@ -10,11 +10,10 @@ const test = anyTest as TestInterface<{
 
 const sessionToken = 'sessionToken';
 const mfaToken = 'mfaToken';
-const apiKey = 'apiKey';
 const baseUrl = 'http://baseurl.com';
 
 test.beforeEach('New ApiService', (t) => {
-  const apiService = new ApiService(sessionToken, mfaToken, apiKey, baseUrl);
+  const apiService = new ApiService(sessionToken, mfaToken, baseUrl);
   const mockAxios = new MockAdapter(apiService.getAxiosInstance());
 
   t.context = {

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -19,7 +19,6 @@ export class ApiService {
   private repoConfig: RepoConstructorConfig = {
     csrfStore: this.csrfStore,
     axiosInstance: this.axiosInstance,
-    apiKey: this.apiKey,
   };
 
   public account = new AccountRepo(this.repoConfig);
@@ -32,7 +31,6 @@ export class ApiService {
   constructor(
     sessionToken: string,
     mfaToken: string,
-    private apiKey: string,
     baseUrl = 'https://www.permanent.org/api'
   ) {
     this.axiosInstance.defaults.headers = createDefaultHeaders(

--- a/src/lib/api/archive.repo.spec.ts
+++ b/src/lib/api/archive.repo.spec.ts
@@ -21,7 +21,6 @@ test.beforeEach('New ArchiveRepo', (t) => {
     archiveRepo: new ArchiveRepo({
       csrfStore,
       axiosInstance,
-      apiKey: 'fakeTestApiKey',
     }),
   };
 });

--- a/src/lib/api/auth.repo.spec.ts
+++ b/src/lib/api/auth.repo.spec.ts
@@ -10,8 +10,6 @@ const test = anyTest as TestInterface<{
   csrfStore: CsrfStore;
 }>;
 
-const apiKey = 'apiKey';
-
 test.beforeEach('New AuthRepo', (t) => {
   const csrfStore = new CsrfStore();
   const axiosInstance = axios.create();
@@ -21,7 +19,6 @@ test.beforeEach('New AuthRepo', (t) => {
     authRepo: new AuthRepo({
       csrfStore,
       axiosInstance,
-      apiKey,
     }),
   };
 });

--- a/src/lib/api/base.repo.spec.ts
+++ b/src/lib/api/base.repo.spec.ts
@@ -13,7 +13,6 @@ const test = anyTest as TestInterface<{
   mockAxios: MockAdapter;
 }>;
 const baseUrl = 'http://test.com';
-const apiKey = 'apiKey';
 
 test.beforeEach('New BaseRepo', (t) => {
   const csrfStore = new CsrfStore();
@@ -29,21 +28,8 @@ test.beforeEach('New BaseRepo', (t) => {
     baseRepo: new BaseRepo({
       csrfStore,
       axiosInstance,
-      apiKey,
     }),
   };
-});
-
-test('requests are made using API key', async (t) => {
-  const endpoint = '/endpoint';
-
-  t.context.mockAxios.onPost(`${baseUrl}${endpoint}`).replyOnce((config) => {
-    const requestData = JSON.parse(config.data) as PermanentApiRequest;
-    t.is(requestData.RequestVO.apiKey, apiKey);
-    return [200, {}];
-  });
-
-  await t.context.baseRepo.request(endpoint);
 });
 
 test('requests are made using csrf from CsrfStore', async (t) => {

--- a/src/lib/api/base.repo.ts
+++ b/src/lib/api/base.repo.ts
@@ -22,18 +22,15 @@ export interface PermanentApiResponse<T = PermanentApiResponseDataBase> {
 export interface RepoConstructorConfig {
   csrfStore: CsrfStore;
   axiosInstance: AxiosInstance;
-  apiKey: string;
 }
 
 export class BaseRepo {
   private csrfStore: CsrfStore;
   private axiosInstance: AxiosInstance;
-  private apiKey: string;
 
   constructor(config: RepoConstructorConfig) {
     this.csrfStore = config.csrfStore;
     this.axiosInstance = config.axiosInstance;
-    this.apiKey = config.apiKey;
   }
 
   async request<
@@ -44,7 +41,6 @@ export class BaseRepo {
   ): Promise<PermanentApiResponse<T>> {
     const requestBody: PermanentApiRequest = {
       RequestVO: {
-        apiKey: this.apiKey,
         csrf: this.csrfStore.getCsrf(),
         data,
       },

--- a/src/lib/api/folder.repo.spec.ts
+++ b/src/lib/api/folder.repo.spec.ts
@@ -12,8 +12,6 @@ const test = anyTest as TestInterface<{
   csrfStore: CsrfStore;
 }>;
 
-const apiKey = 'apiKey';
-
 test.beforeEach('New FolderRepo', (t) => {
   const csrfStore = new CsrfStore();
   const axiosInstance = axios.create();
@@ -23,7 +21,6 @@ test.beforeEach('New FolderRepo', (t) => {
     folderRepo: new FolderRepo({
       csrfStore,
       axiosInstance,
-      apiKey,
     }),
   };
 });

--- a/src/lib/api/record.repo.spec.ts
+++ b/src/lib/api/record.repo.spec.ts
@@ -12,8 +12,6 @@ const test = anyTest as TestInterface<{
   csrfStore: CsrfStore;
 }>;
 
-const apiKey = 'apiKey';
-
 test.beforeEach('New RecordRepo', (t) => {
   const csrfStore = new CsrfStore();
   const axiosInstance = axios.create();
@@ -23,7 +21,6 @@ test.beforeEach('New RecordRepo', (t) => {
     recordRepo: new RecordRepo({
       csrfStore,
       axiosInstance,
-      apiKey,
     }),
   };
 });

--- a/src/lib/api/share.repo.spec.ts
+++ b/src/lib/api/share.repo.spec.ts
@@ -17,8 +17,6 @@ const test = anyTest as TestInterface<{
   csrfStore: CsrfStore;
 }>;
 
-const apiKey = 'apiKey';
-
 test.beforeEach('New ShareRepo', (t) => {
   const csrfStore = new CsrfStore();
   const axiosInstance = axios.create();
@@ -28,7 +26,6 @@ test.beforeEach('New ShareRepo', (t) => {
     shareRepo: new ShareRepo({
       csrfStore,
       axiosInstance,
-      apiKey,
     }),
   };
 });

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -10,7 +10,6 @@ const test = anyTest as TestInterface<{
 
 test.beforeEach((t) => {
   const options: PermanentConstructorConfigI = {
-    apiKey: 'apiapiapi',
     archiveId: 1,
     sessionToken: 'sessionsessionsession',
     mfaToken: 'mfamfamfa',
@@ -27,18 +26,6 @@ test('instance gets config options', (t) => {
   t.is(t.context.permanent.getSessionToken(), t.context.options.sessionToken);
   t.is(t.context.permanent.getMfaToken(), t.context.options.mfaToken);
   t.is(t.context.permanent.getArchiveNbr(), t.context.options.archiveNbr);
-});
-
-test('throws error for missing apiKey', async (t) => {
-  const error = t.throws(() => {
-    new Permanent(({
-      ...t.context.options,
-      ...{ apiKey: undefined },
-    } as unknown) as PermanentConstructorConfigI);
-  });
-
-  t.assert(error instanceof PermSdkError);
-  t.assert(error.message.includes('apiKey'));
 });
 
 test('throws error for missing sessionToken', async (t) => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -11,12 +11,10 @@ export interface PermanentConstructorConfigI {
   mfaToken: string;
   archiveId?: number;
   archiveNbr?: string;
-  apiKey: string;
   baseUrl?: string;
 }
 
 export class Permanent {
-  private apiKey: string;
   private sessionToken: string;
   private mfaToken: string;
   private archiveId?: number;
@@ -31,14 +29,7 @@ export class Permanent {
 
   public archiveStore = new ArchiveStore();
   constructor(config: PermanentConstructorConfigI) {
-    const {
-      sessionToken,
-      mfaToken,
-      archiveId,
-      archiveNbr,
-      apiKey,
-      baseUrl,
-    } = config;
+    const { sessionToken, mfaToken, archiveId, archiveNbr, baseUrl } = config;
 
     if (!sessionToken) {
       throw new PermSdkError('Missing sessionToken in config');
@@ -48,16 +39,11 @@ export class Permanent {
       throw new PermSdkError('Missing mfaToken in config');
     }
 
-    if (!apiKey) {
-      throw new PermSdkError('Missing apiKey in config');
-    }
-
     this.sessionToken = sessionToken;
     this.mfaToken = mfaToken;
     this.archiveId = archiveId;
     this.archiveNbr = archiveNbr;
-    this.apiKey = apiKey;
-    this.api = new ApiService(sessionToken, mfaToken, this.apiKey, baseUrl);
+    this.api = new ApiService(sessionToken, mfaToken, baseUrl);
     this.folder = new FolderResource(this.api, this.archiveStore);
     this.record = new RecordResource(this.api, this.archiveStore);
     this.session = new SessionResource(this.api, this.archiveStore);

--- a/src/lib/model/request-vo.ts
+++ b/src/lib/model/request-vo.ts
@@ -29,7 +29,6 @@ export interface PermanentApiRequestData {
 }
 
 export interface RequestVO {
-  apiKey: string;
   csrf?: string;
   data: PermanentApiRequestData[] | PermanentApiRequestData;
 }


### PR DESCRIPTION
The Permanent API no longer requires an API key. Requests don't need to include it, no behavior is gated on it, and soon the API won't even know what an API key is. Stop requiring the key during initialization, and stop sending it with requests.

PER-8278 Rotate or delete Permanent API key