### PR TITLE
Add npm prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "version": "standard-version",
     "reset-hard": "git clean -dfx && git reset --hard && npm i",
-    "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish"
+    "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds an `npm prepare` script so that this repository can be installed as an NPM package. This is to *prepare* for publishing this package to NPM, but for now this makes working with this library much easier.

- **What is the current behavior?** (You can also link to an open issue here)
You can technically run `npm install PermanentOrg/node-sdk` right now to attempt installing this Github repo as a dependency, but it doesn't actually work as the project isn't built during the installation process.

- **What is the new behavior (if this is a feature change)?**
This runs the build process during installation so that we can actually install this as a dependency and it works.

- **Other information**:
I actually forked this repo so we can properly test it. You should be able to test out that this installs properly with this process:
  - Create a blank npm project somewhere on your system in an empty folder using `npm init`
  - Run `npm install meisekimiu/node-sdk`.
  - Create an `index.js` file that imports the Permanent Node SDK. This is my basic file I used for testing:
```javascript
const Permanent = require('@permanentorg/node-sdk').Permanent;

console.log(Permanent);
console.log("Does it work?");
```
  - Upon running `node index.js`, you should see that Permanent is properly imported in. There are no errors and the `Permanent` const is a function.
  - Go into the `package.json` for this temporary project and replace `meisekimiu/node-sdk` with `PermanentOrg/node-sdk`. Delete the `node_modules` folder and run `npm install`.
  - Run `node index.js` again and you should see errors as Permanent is undefined.
  - You should be able to swap back to my fork again, run `npm install`, and have it working again.