### PR TITLE
Add copy/publish functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,16 @@ const folderShareUrl = await permanent.share.createFolderShareLink(
 );
 ```
 
+### Copying items
+You can copy items to a specific folder using the `item.copy` method which works on both folders and records. There are also separate type-specific methods, `folder.copy` and `record.copy`.
+
+```js
+const privateRoot = await permanent.folder.getMyFilesFolder();
+const publicRoot = await permanent.folder.getPublicFolder();
+const firstChild = privateRoot.ChildItemVOs.shift();
+
+// Copies the first item in "My Files" to the Public Workspace
+await permanent.item.copy(firstChild, publicRoot);
+```
+
+Copying to the Public Root (accessible by using `folder.getPublicFolder`) is functionally equivalent to publishing a file in the Permanent web app.

--- a/examples/copy-publish.js
+++ b/examples/copy-publish.js
@@ -1,0 +1,57 @@
+// To run this script, use `node share.js`
+//
+// Uncomment this line to run on an insecure local environment, if you
+// like:
+// process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+const permSdk = require('@permanentorg/node-sdk');
+
+// You can pull the "permSession" and "permMFA" cookie values from
+// devtools on any request.  Include
+//
+// 'baseUrl': 'https://local.permanent.org/api'
+//
+// or similar if you want to run this locally or on another
+// environment (by default it will run against prod)
+
+const permanent = new permSdk.Permanent({
+    'sessionToken': 'permSession_COOKIE',
+    'mfaToken': 'permMFA_COOKIE',
+    'archiveNbr': 'YOUR_ARCHIVE',
+});
+
+run();
+
+function randomElement(array) {
+    return array[Math.floor(Math.random() * array.length)];
+}
+
+async function run() {
+    await permanent.init();
+    console.log('session started');
+
+    // I want to copy a random item from "My Files" to "Public"
+    // In other words, we're publishing a random file from "My Files"!
+    const root = await permanent.folder.getMyFilesFolder();
+    const public = await permanent.folder.getPublicFolder();
+    const randomChild = randomElement(root.ChildItemVOs);
+
+    console.log(`Copying "${randomChild.displayName}" to Public...`);
+
+    /*
+    You must call the proper API endpoint to copy a folder vs a record.
+    Right now when you're handed an arbitrary list of ItemVOs like we are doing
+    here, you have to manually check whether an Item is a folder or record.
+
+    Hopefully, in the future, this will be smoothed out a bit more.
+    */
+    let result;
+    if (randomChild.type.includes('folder')) {
+      // The API takes an array of items to copy in case you want to copy multiple
+      result = await permanent.folder.copy([randomChild], public);
+    } else {
+      result = await permanent.record.copy([randomChild], public);
+    }
+
+    console.log('Done!');
+}

--- a/examples/copy-publish.js
+++ b/examples/copy-publish.js
@@ -1,4 +1,4 @@
-// To run this script, use `node share.js`
+// To run this script, use `node copy-publish.js`
 //
 // Uncomment this line to run on an insecure local environment, if you
 // like:
@@ -30,13 +30,13 @@ async function run() {
     await permanent.init();
     console.log('session started');
 
-    const root = await permanent.folder.getMyFilesFolder();
-    const public = await permanent.folder.getPublicFolder();
-    const randomChild = randomElement(root.ChildItemVOs);
+    const privateRoot = await permanent.folder.getMyFilesFolder();
+    const publicRoot = await permanent.folder.getPublicFolder();
+    const randomChild = randomElement(privateRoot.ChildItemVOs);
 
     if (randomChild) {
       console.log(`Copying "${randomChild.displayName}" to Public...`);
-      const result = await permanent.item.copy(randomChild, public);
+      const result = await permanent.item.copy(randomChild, publicRoot);
     }
 
     console.log('Done!');

--- a/examples/copy-publish.js
+++ b/examples/copy-publish.js
@@ -30,27 +30,13 @@ async function run() {
     await permanent.init();
     console.log('session started');
 
-    // I want to copy a random item from "My Files" to "Public"
-    // In other words, we're publishing a random file from "My Files"!
     const root = await permanent.folder.getMyFilesFolder();
     const public = await permanent.folder.getPublicFolder();
     const randomChild = randomElement(root.ChildItemVOs);
 
-    console.log(`Copying "${randomChild.displayName}" to Public...`);
-
-    /*
-    You must call the proper API endpoint to copy a folder vs a record.
-    Right now when you're handed an arbitrary list of ItemVOs like we are doing
-    here, you have to manually check whether an Item is a folder or record.
-
-    Hopefully, in the future, this will be smoothed out a bit more.
-    */
-    let result;
-    if (randomChild.type.includes('folder')) {
-      // The API takes an array of items to copy in case you want to copy multiple
-      result = await permanent.folder.copy([randomChild], public);
-    } else {
-      result = await permanent.record.copy([randomChild], public);
+    if (randomChild) {
+      console.log(`Copying "${randomChild.displayName}" to Public...`);
+      const result = await permanent.item.copy(randomChild, public);
     }
 
     console.log('Done!');

--- a/src/lib/api/folder.repo.spec.ts
+++ b/src/lib/api/folder.repo.spec.ts
@@ -2,7 +2,7 @@ import anyTest, { TestInterface } from 'ava';
 import axios from 'axios';
 import * as sinon from 'sinon';
 
-import { PermanentApiRequestData } from '../model';
+import { FolderVO, PermanentApiRequestData } from '../model';
 
 import { CsrfStore } from './csrf';
 import { FolderRepo } from './folder.repo';
@@ -57,4 +57,46 @@ test('should call post endpoint with proper FolderVO structure', async (t) => {
   await t.context.folderRepo.post(displayName, parentFolder_linkId);
 
   t.assert(requestFake.calledOnceWith('/folder/post', expectedRequestData));
+});
+
+test('should call the getPublicRoot endpoint', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+
+  sinon.replace(t.context.folderRepo, 'request', requestFake);
+
+  await t.context.folderRepo.getPublicRoot();
+
+  t.assert(requestFake.calledOnceWith('/folder/getPublicRoot'));
+});
+
+test('should call the copy endpoint', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+
+  sinon.replace(t.context.folderRepo, 'request', requestFake);
+
+  const folder: FolderVO = {
+    folderId: 1,
+    folder_linkId: 1,
+  };
+
+  const destination: FolderVO = {
+    folderId: 2,
+    folder_linkId: 2,
+  };
+
+  await t.context.folderRepo.copy([folder], destination);
+
+  const expectedRequestData: PermanentApiRequestData[] = [
+    {
+      FolderVO: {
+        folderId: 1,
+        folder_linkId: 1,
+      },
+      FolderDestVO: {
+        folder_linkId: 2,
+      },
+    },
+  ];
+
+  t.assert(requestFake.calledOnceWith('/folder/copy', expectedRequestData));
 });

--- a/src/lib/api/folder.repo.ts
+++ b/src/lib/api/folder.repo.ts
@@ -17,6 +17,10 @@ export class FolderRepo extends BaseRepo {
     return this.request<FolderResponse>('/folder/getAppRoot');
   }
 
+  public getPublicRoot() {
+    return this.request<FolderResponse>('/folder/getPublicRoot');
+  }
+
   public getWithChildren(rootFolderVO: FolderVO) {
     const requestData: PermanentApiRequestData = {
       FolderVO: rootFolderVO,
@@ -35,5 +39,18 @@ export class FolderRepo extends BaseRepo {
     };
 
     return this.request<FolderResponse>('/folder/post', [requestData]);
+  }
+
+  public copy(folderVOs: FolderVO[], destination: FolderVO) {
+    const requestData: PermanentApiRequestData[] = folderVOs.map((folderVO) => {
+      return {
+        FolderVO: folderVO,
+        FolderDestVO: {
+          folder_linkId: destination.folder_linkId,
+        },
+      };
+    });
+
+    return this.request<FolderResponse>('/folder/copy', requestData);
   }
 }

--- a/src/lib/api/folder.repo.ts
+++ b/src/lib/api/folder.repo.ts
@@ -42,14 +42,14 @@ export class FolderRepo extends BaseRepo {
   }
 
   public copy(folderVOs: FolderVO[], destination: FolderVO) {
-    const requestData: PermanentApiRequestData[] = folderVOs.map((folderVO) => {
-      return {
+    const requestData: PermanentApiRequestData[] = folderVOs.map(
+      (folderVO) => ({
         FolderVO: folderVO,
         FolderDestVO: {
           folder_linkId: destination.folder_linkId,
         },
-      };
-    });
+      })
+    );
 
     return this.request<FolderResponse>('/folder/copy', requestData);
   }

--- a/src/lib/api/record.repo.spec.ts
+++ b/src/lib/api/record.repo.spec.ts
@@ -2,7 +2,12 @@ import anyTest, { TestInterface } from 'ava';
 import axios from 'axios';
 import * as sinon from 'sinon';
 
-import { PermanentApiRequestData, RecordVOFromUrl } from '../model';
+import {
+  FolderVO,
+  PermanentApiRequestData,
+  RecordVO,
+  RecordVOFromUrl,
+} from '../model';
 
 import { CsrfStore } from './csrf';
 import { RecordRepo } from './record.repo';
@@ -58,4 +63,35 @@ test('should call post endpoint with proper RecordVO structure', async (t) => {
   );
 
   t.assert(requestFake.calledOnceWith('/record/post', expectedRequestData));
+});
+
+test('should call copy endpoint', async (t) => {
+  const requestFake = sinon.fake.resolves(true);
+  sinon.replace(t.context.recordRepo, 'request', requestFake);
+
+  const record: RecordVO = {
+    displayName: 'File',
+    folder_linkId: 1,
+    uploadFileName: 'File.png',
+    parentFolderId: 1,
+    parentFolder_linkId: 1,
+  };
+
+  const destination: FolderVO = {
+    folderId: 2,
+    folder_linkId: 2,
+  };
+
+  const expectedRequestData = [
+    {
+      RecordVO: record,
+      FolderDestVO: {
+        folder_linkId: 2,
+      },
+    },
+  ];
+
+  await t.context.recordRepo.copy([record], destination);
+
+  t.assert(requestFake.calledOnceWith('/record/copy', expectedRequestData));
 });

--- a/src/lib/api/record.repo.ts
+++ b/src/lib/api/record.repo.ts
@@ -92,14 +92,12 @@ export class RecordRepo extends BaseRepo {
   }
 
   public copy(records: RecordVO[], destination: FolderVO) {
-    const requestData: PermanentApiRequestData[] = records.map((recordVO) => {
-      return {
-        RecordVO: recordVO,
-        FolderDestVO: {
-          folder_linkId: destination.folder_linkId,
-        },
-      };
-    });
+    const requestData: PermanentApiRequestData[] = records.map((recordVO) => ({
+      RecordVO: recordVO,
+      FolderDestVO: {
+        folder_linkId: destination.folder_linkId,
+      },
+    }));
 
     return this.request<RecordResponse>('/record/copy', requestData);
   }

--- a/src/lib/api/record.repo.ts
+++ b/src/lib/api/record.repo.ts
@@ -1,4 +1,5 @@
 import {
+  FolderVO,
   PermanentApiRequestData,
   PermanentApiResponseData,
   RecordVO,
@@ -88,5 +89,18 @@ export class RecordRepo extends BaseRepo {
       ],
     };
     return this.request<RecordResponse>('/record/registerRecord', requestData);
+  }
+
+  public copy(records: RecordVO[], destination: FolderVO) {
+    const requestData: PermanentApiRequestData[] = records.map((recordVO) => {
+      return {
+        RecordVO: recordVO,
+        FolderDestVO: {
+          folder_linkId: destination.folder_linkId,
+        },
+      };
+    });
+
+    return this.request<RecordResponse>('/record/copy', requestData);
   }
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2,6 +2,7 @@ import { ApiService } from './api/api.service';
 import { PermSdkError } from './error';
 import { ArchiveStore } from './resources/archive';
 import { FolderResource } from './resources/folder.resource';
+import { ItemResource } from './resources/item.resource';
 import { RecordResource } from './resources/record.resource';
 import { SessionResource } from './resources/session.resource';
 import { ShareResource } from './resources/share.resource';
@@ -23,6 +24,7 @@ export class Permanent {
   public api: ApiService;
 
   public folder: FolderResource;
+  public item: ItemResource;
   public record: RecordResource;
   public session: SessionResource;
   public share: ShareResource;
@@ -46,6 +48,7 @@ export class Permanent {
     this.api = new ApiService(sessionToken, mfaToken, baseUrl);
     this.folder = new FolderResource(this.api, this.archiveStore);
     this.record = new RecordResource(this.api, this.archiveStore);
+    this.item = new ItemResource(this.folder, this.record);
     this.session = new SessionResource(this.api, this.archiveStore);
     this.share = new ShareResource(this.api);
   }

--- a/src/lib/model/folder-vo.ts
+++ b/src/lib/model/folder-vo.ts
@@ -31,5 +31,6 @@ export interface FolderVO extends BaseVO {
 }
 
 export type ParentFolderVO = Pick<FolderVO, 'folder_linkId'>;
+export type DestinationFolderVO = Pick<FolderVO, 'folder_linkId'>;
 
 export type Folder = FolderVO;

--- a/src/lib/model/index.ts
+++ b/src/lib/model/index.ts
@@ -1,3 +1,6 @@
+import { FolderVO } from './folder-vo';
+import { RecordVO } from './record-vo';
+
 export * from './account-vo';
 export * from './archive-vo';
 export * from './folder-vo';
@@ -5,3 +8,5 @@ export * from './record-vo';
 export * from './request-vo';
 export * from './share-by-url-vo';
 export * from './simple-vo';
+
+export type ItemVO = FolderVO | RecordVO;

--- a/src/lib/model/request-vo.ts
+++ b/src/lib/model/request-vo.ts
@@ -1,6 +1,6 @@
 import { AccountVO } from './account-vo';
 import { ArchiveVO } from './archive-vo';
-import { FolderVO } from './folder-vo';
+import { DestinationFolderVO, FolderVO } from './folder-vo';
 import { RecordVO } from './record-vo';
 import { ShareByUrlVO } from './share-by-url-vo';
 import { SimpleVO } from './simple-vo';
@@ -22,6 +22,7 @@ export interface PermanentApiRequestData {
   ArchiveVO?: Partial<ArchiveVO>;
   AccountVO?: Partial<AccountVO>;
   FolderVO?: Partial<FolderVO>;
+  FolderDestVO?: DestinationFolderVO;
   RecordVO?: Partial<RecordVO>;
   SimpleVO?: Partial<SimpleVO>;
   SimpleVOs?: Partial<SimpleVO>[];

--- a/src/lib/resources/folder.resource.ts
+++ b/src/lib/resources/folder.resource.ts
@@ -53,4 +53,43 @@ export class FolderResource extends BaseResource {
     );
     return this.getVoFromResponse<FolderResponse>(response, 'FolderVO');
   }
+
+  public async getPublicFolder(): Promise<FolderVO> {
+    const publicResponse = await this.api.folder.getPublicRoot();
+    const publicRoot = this.getVoFromResponse<FolderResponse>(
+      publicResponse,
+      'FolderVO'
+    );
+    const response = await this.api.folder.getWithChildren(publicRoot);
+    return this.getVoFromResponse<FolderResponse>(response, 'FolderVO');
+  }
+
+  public async getMyFilesFolder(): Promise<FolderVO> {
+    const response = await this.api.folder.getWithChildren(
+      this.archiveStore.getPrivateRoot()
+    );
+
+    return this.getVoFromResponse<FolderResponse>(response, 'FolderVO');
+  }
+
+  /**
+   * Copies an array of folders to the destination folder
+   *
+   * @returns a Promise that resolves to the newly copied folder
+   */
+  public async copy(
+    folderVOs: FolderVO[],
+    destination: FolderVO
+  ): Promise<FolderVO> {
+    const response = await this.api.folder.copy(folderVOs, destination);
+
+    if (!response.isSuccessful) {
+      throw new PermSdkError(
+        'folder could not be copied',
+        response.Results[0].message
+      );
+    }
+
+    return this.getVoFromResponse<FolderResponse>(response, 'FolderVO');
+  }
 }

--- a/src/lib/resources/item.resource.spec.ts
+++ b/src/lib/resources/item.resource.spec.ts
@@ -1,0 +1,108 @@
+import anyTest, { TestInterface } from 'ava';
+import * as sinon from 'sinon';
+
+import { ApiService } from '../api/api.service';
+import { FolderVO, RecordVO } from '../model';
+
+import { ArchiveStore } from './archive';
+import { FolderResource } from './folder.resource';
+import { ItemResource } from './item.resource';
+import { RecordResource } from './record.resource';
+
+const test = anyTest as TestInterface<{
+  api: ApiService;
+  archiveStore: ArchiveStore;
+  folder: FolderResource;
+  item: ItemResource;
+  record: RecordResource;
+}>;
+
+test.beforeEach((t) => {
+  const api = new ApiService('session', 'mfa', 'test');
+  const archiveStore = new ArchiveStore();
+
+  archiveStore.setRoot({
+    folderId: 1,
+    folder_linkId: 1,
+    ChildItemVOs: [
+      {
+        folderId: 2,
+        folder_linkId: 2,
+        type: 'type.folder.root.private',
+      },
+    ],
+  });
+
+  const folder = new FolderResource(api, archiveStore);
+  const record = new RecordResource(api, archiveStore);
+  const item = new ItemResource(folder, record);
+  t.context = {
+    api,
+    archiveStore,
+    folder,
+    item,
+    record,
+  };
+});
+
+test('should create', (t) => {
+  t.assert(t.context.item);
+});
+
+test('should be able to call proper copy endpoint', async (t) => {
+  const destinationFolder: FolderVO = {
+    folderId: 1,
+    folder_linkId: 1,
+  };
+  const folder: FolderVO = {
+    folderId: 2,
+    folder_linkId: 2,
+  };
+  const record: RecordVO = {
+    displayName: 'Potato',
+    folder_linkId: 3,
+    uploadFileName: 'Potato.gif',
+    parentFolderId: 2,
+    parentFolder_linkId: 2,
+  };
+
+  const folderFake = sinon.fake.resolves({
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            FolderVO: folder,
+          },
+        ],
+      },
+    ],
+  });
+  const recordFake = sinon.fake.resolves({
+    csrf: 'csrf',
+    isSuccessful: true,
+    isSystemUp: true,
+    Results: [
+      {
+        data: [
+          {
+            RecordVO: record,
+          },
+        ],
+      },
+    ],
+  });
+
+  sinon.replace(t.context.api.folder, 'request', folderFake);
+  sinon.replace(t.context.api.record, 'request', recordFake);
+
+  t.assert(!folderFake.called);
+  t.assert(!recordFake.called);
+  t.context.item.copy(folder, destinationFolder);
+  t.assert(folderFake.calledOnceWith('/folder/copy'));
+  t.assert(!recordFake.called);
+  t.context.item.copy(record, destinationFolder);
+  t.assert(recordFake.calledOnceWith('/record/copy'));
+});

--- a/src/lib/resources/item.resource.ts
+++ b/src/lib/resources/item.resource.ts
@@ -1,0 +1,26 @@
+import { FolderVO, ItemVO, RecordVO } from '../model';
+
+import { FolderResource } from './folder.resource';
+import { RecordResource } from './record.resource';
+
+export class ItemResource {
+  constructor(
+    protected folder: FolderResource,
+    protected record: RecordResource
+  ) {}
+
+  public async copy(item: ItemVO, destination: FolderVO): Promise<ItemVO> {
+    if (this.isItemARecord(item)) {
+      return await this.record.copy([item as RecordVO], destination);
+    } else {
+      return await this.folder.copy([item as FolderVO], destination);
+    }
+  }
+
+  protected isItemARecord(item: ItemVO): boolean {
+    const record = item as RecordVO;
+    return typeof record.uploadFileName !== 'undefined';
+    // HACK: uploadFileName is the only required property
+    // we can use to distinguish between FolderVOs and RecordVOs.
+  }
+}

--- a/src/lib/resources/record.resource.ts
+++ b/src/lib/resources/record.resource.ts
@@ -2,7 +2,7 @@ import { ApiService } from '../api/api.service';
 import { SimpleVOResponse } from '../api/auth.repo';
 import { RecordResponse } from '../api/record.repo';
 import { PermSdkError } from '../error';
-import { ParentFolderVO, RecordVO, RecordVOFromUrl } from '../model';
+import { FolderVO, ParentFolderVO, RecordVO, RecordVOFromUrl } from '../model';
 
 import { ArchiveStore } from './archive';
 import { BaseResource } from './base.resource';
@@ -106,6 +106,27 @@ export class RecordResource extends BaseResource {
         response.Results[0].message
       );
     }
+    return this.getVoFromResponse<RecordResponse>(response, 'RecordVO');
+  }
+
+  /**
+   * Copies an array of records to the destination folder
+   *
+   * @returns a Promise that resolves to the newly copied record
+   */
+  public async copy(
+    records: RecordVO[],
+    destination: FolderVO
+  ): Promise<RecordVO> {
+    const response = await this.api.record.copy(records, destination);
+
+    if (!response.isSuccessful) {
+      throw new PermSdkError(
+        'record could not be copied',
+        response.Results[0].message
+      );
+    }
+
     return this.getVoFromResponse<RecordResponse>(response, 'RecordVO');
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
This PR adds copy/publish functionality to the node-sdk. In addition to adding copy methods for both records and folders, there's also a function to fetch the Public Root, so publishing functionality (which is just copying to Public in the back end) can be properly implemented by scripts. I've also added a function to fetch the My Files folder so that I can test copying from "My Files" to "Public".

- **What is the current behavior?** (You can also link to an open issue here)
<span title="... Which really begs the question, what *can* be done with the node-sdk right now?">You cannot copy, fetch the Public Root, or My Files directories.</span>

- **What is the new behavior (if this is a feature change)?**
Adds those things.

- **Other information**:
I'm a bit unclear on the design of the architecture we want on this project... should this be how it's implemented? I kind of have to do an ugly thing in the `copy-publish.js` example file I made where I have to explicitly check whether an Item is a record or a folder before calling the exact method on it.