### PR TITLE
Require Node.js 12 or later

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "npm run build"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "dependencies": {
     "axios": "^0.21.2"


### PR DESCRIPTION
The 10.x release line of Node.js left security support in April 2021. Stop supporting and testing the SDK with Node.js 10.x, both to narrow our support matrix and to allow us to add new dependencies that require more recent versions.

Start testing with the 16.x release line, to make sure that we maintain forward compatibility.