### PR TITLE
Login and authenticate via OAuth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -370,6 +370,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -440,6 +453,24 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3493,6 +3524,18 @@
       "resolved": "https://registry.npmjs.org/iterable-to-stream/-/iterable-to-stream-1.0.1.tgz",
       "integrity": "sha512-O62gD5ADMUGtJoOoM9U6LQ7i4byPXUNoHJ6mqsmkQJcom331ZJGDApWgDESWyBMEHEJRjtHozgIiTzYo9RU4UA==",
       "dev": true
+    },
+    "joi": {
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.3.tgz",
+      "integrity": "sha512-8W3oOogFRuy2aLAdlhMpzS4fNBIMiyIa3xBaBYMFgA272/d5sob1DAth6jjo+5VrOlzbEgmbBGbU4cLrffPKog==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -370,6 +370,19 @@
         }
       }
     },
+    "@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+    },
     "@hapi/hoek": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
@@ -381,6 +394,16 @@
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+      "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@humanwhocodes/config-array": {
@@ -566,6 +589,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/simple-oauth2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/simple-oauth2/-/simple-oauth2-4.1.1.tgz",
+      "integrity": "sha512-8jqhfUFb0FoCl2Od4czprB7ubM8/Fuo3tg+vQZ00zYtPcNLogGyDgm2DVfVvD3NYXK7AscKOXSaW33NHUWpNBg==",
       "dev": true
     },
     "@types/sinon": {
@@ -1889,7 +1918,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
       "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4072,8 +4100,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5298,6 +5325,17 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-oauth2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/simple-oauth2/-/simple-oauth2-4.2.0.tgz",
+      "integrity": "sha512-AV62tGdq9JfLd/uveKpeNtQl+VVm89a35QKlwGuvisYIjCoz2ZmTGRGuSIGiYr+QUhSKJ5kYN1jq2BBa/ac/GQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/wreck": "^17.0.0",
+        "debug": "^4.1.1",
+        "joi": "^17.3.0"
+      }
     },
     "sinon": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,14 @@
   },
   "dependencies": {
     "axios": "^0.21.2",
-    "joi": "^17.4.3"
+    "joi": "^17.4.3",
+    "simple-oauth2": "^4.2.0"
   },
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/node": "^14.11.8",
+    "@types/simple-oauth2": "^4.1.1",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "ava": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "node": ">=12"
   },
   "dependencies": {
-    "axios": "^0.21.2"
+    "axios": "^0.21.2",
+    "joi": "^17.4.3"
   },
   "devDependencies": {
     "@ava/typescript": "^1.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Permanent } from './lib/client';
 export { AccessRole } from './lib/enum/access-role';
+export { PermanentOAuthClient } from './lib/oauth-client';

--- a/src/lib/api/api.service.spec.ts
+++ b/src/lib/api/api.service.spec.ts
@@ -13,7 +13,7 @@ const mfaToken = 'mfaToken';
 const baseUrl = 'http://baseurl.com';
 
 test.beforeEach('New ApiService', (t) => {
-  const apiService = new ApiService(sessionToken, mfaToken, baseUrl);
+  const apiService = ApiService.fromSession(sessionToken, mfaToken, baseUrl);
   const mockAxios = new MockAdapter(apiService.getAxiosInstance());
 
   t.context = {

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
 
 import { AccountRepo } from './account.repo';
 import { ArchiveRepo } from './archive.repo';
@@ -28,25 +29,24 @@ export class ApiService {
   public record = new RecordRepo(this.repoConfig);
   public share = new ShareRepo(this.repoConfig);
 
-  constructor(
+  private constructor(defaultConfig: AxiosRequestConfig) {
+    Object.assign(this.axiosInstance.defaults, defaultConfig);
+  }
+
+  public static fromSession(
     sessionToken: string,
     mfaToken: string,
-    baseUrl = 'https://www.permanent.org/api'
+    baseURL = 'https://www.permanent.org/api'
   ) {
-    this.axiosInstance.defaults.headers = createDefaultHeaders(
-      sessionToken,
-      mfaToken
-    );
-    this.axiosInstance.defaults.baseURL = baseUrl;
+    return new ApiService({
+      baseURL,
+      headers: {
+        Cookie: `${SESSION_COOKIE}=${sessionToken}; ${MFA_COOKIE}=${mfaToken};`,
+      },
+    });
   }
 
   getAxiosInstance() {
     return this.axiosInstance;
   }
-}
-
-function createDefaultHeaders(sessionToken: string, mfaToken: string) {
-  return {
-    Cookie: `${SESSION_COOKIE}=${sessionToken}; ${MFA_COOKIE}=${mfaToken};`,
-  };
 }

--- a/src/lib/api/api.service.ts
+++ b/src/lib/api/api.service.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type { AxiosRequestConfig } from 'axios';
+import type { AccessToken } from 'simple-oauth2';
 
 import { AccountRepo } from './account.repo';
 import { ArchiveRepo } from './archive.repo';
@@ -42,6 +43,18 @@ export class ApiService {
       baseURL,
       headers: {
         Cookie: `${SESSION_COOKIE}=${sessionToken}; ${MFA_COOKIE}=${mfaToken};`,
+      },
+    });
+  }
+
+  public static fromToken(
+    accessToken: AccessToken,
+    baseURL = 'https://www.permanent.org/api'
+  ) {
+    return new ApiService({
+      baseURL,
+      headers: {
+        Authorization: `Bearer ${accessToken.token.access_token}`,
       },
     });
   }

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -1,7 +1,6 @@
 import anyTest, { TestInterface } from 'ava';
 
 import { Permanent, PermanentConstructorConfigI } from './client';
-import { PermSdkError } from './error';
 
 const test = anyTest as TestInterface<{
   permanent: Permanent;
@@ -36,7 +35,6 @@ test('throws error for missing sessionToken', async (t) => {
     } as unknown) as PermanentConstructorConfigI);
   });
 
-  t.assert(error instanceof PermSdkError);
   t.assert(error.message.includes('sessionToken'));
 });
 
@@ -48,6 +46,5 @@ test('throws error for missing mfaToken', async (t) => {
     } as unknown) as PermanentConstructorConfigI);
   });
 
-  t.assert(error instanceof PermSdkError);
   t.assert(error.message.includes('mfaToken'));
 });

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -1,9 +1,9 @@
 import anyTest, { TestInterface } from 'ava';
+import { AuthorizationCode } from 'simple-oauth2';
 
 import { Permanent, PermanentConstructorConfigI } from './client';
 
 const test = anyTest as TestInterface<{
-  permanent: Permanent;
   options: PermanentConstructorConfigI;
 }>;
 
@@ -16,15 +16,16 @@ test.beforeEach((t) => {
   };
   t.context = {
     options,
-    permanent: new Permanent(options),
   };
 });
 
-test('instance gets config options', (t) => {
-  t.truthy(t.context.permanent);
-  t.is(t.context.permanent.getSessionToken(), t.context.options.sessionToken);
-  t.is(t.context.permanent.getMfaToken(), t.context.options.mfaToken);
-  t.is(t.context.permanent.getArchiveNbr(), t.context.options.archiveNbr);
+test('session instance gets config options', (t) => {
+  const permanent = new Permanent(t.context.options);
+  t.truthy(permanent);
+  t.is(permanent.getSessionToken(), t.context.options.sessionToken);
+  t.is(permanent.getMfaToken(), t.context.options.mfaToken);
+  t.is(permanent.getArchiveNbr(), t.context.options.archiveNbr);
+  t.is(permanent.getAccessToken(), undefined);
 });
 
 test('throws error for missing sessionToken', async (t) => {
@@ -47,4 +48,34 @@ test('throws error for missing mfaToken', async (t) => {
   });
 
   t.assert(error.message.includes('mfaToken'));
+});
+
+test('throws error for missing authentication', async (t) => {
+  const error = t.throws(() => {
+    new Permanent({});
+  });
+
+  t.assert(error.message.includes('at least one of'));
+  t.assert(error.message.includes('accessToken'));
+  t.assert(error.message.includes('sessionToken'));
+});
+
+test('works with an access token', async (t) => {
+  const client = new AuthorizationCode({
+    client: { id: 'id', secret: 'secret' },
+    auth: { tokenHost: 'http://example.com' },
+  });
+  const accessToken = client.createToken({
+    access_token: 'token',
+    expires_in: 123,
+    token_type: 'Bearer',
+  });
+  const permanent = new Permanent({
+    accessToken,
+  });
+
+  t.truthy(permanent);
+  t.is(permanent.getAccessToken(), accessToken);
+  t.is(permanent.getSessionToken(), undefined);
+  t.is(permanent.getMfaToken(), undefined);
 });

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,5 +1,6 @@
+import Joi from 'joi';
+
 import { ApiService } from './api/api.service';
-import { PermSdkError } from './error';
 import { ArchiveStore } from './resources/archive';
 import { FolderResource } from './resources/folder.resource';
 import { ItemResource } from './resources/item.resource';
@@ -14,6 +15,14 @@ export interface PermanentConstructorConfigI {
   archiveNbr?: string;
   baseUrl?: string;
 }
+
+const schema = Joi.object({
+  sessionToken: Joi.string().required(),
+  mfaToken: Joi.string().required(),
+  archiveId: Joi.number().optional(),
+  archiveNbr: Joi.string().optional(),
+  baseUrl: Joi.string().optional(),
+});
 
 export class Permanent {
   private sessionToken: string;
@@ -31,15 +40,14 @@ export class Permanent {
 
   public archiveStore = new ArchiveStore();
   constructor(config: PermanentConstructorConfigI) {
+    Joi.assert(
+      config,
+      schema,
+      '@permanentorg/node-sdk: Invalid configuration',
+      { abortEarly: false }
+    );
+
     const { sessionToken, mfaToken, archiveId, archiveNbr, baseUrl } = config;
-
-    if (!sessionToken) {
-      throw new PermSdkError('Missing sessionToken in config');
-    }
-
-    if (!mfaToken) {
-      throw new PermSdkError('Missing mfaToken in config');
-    }
 
     this.sessionToken = sessionToken;
     this.mfaToken = mfaToken;

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -45,7 +45,7 @@ export class Permanent {
     this.mfaToken = mfaToken;
     this.archiveId = archiveId;
     this.archiveNbr = archiveNbr;
-    this.api = new ApiService(sessionToken, mfaToken, baseUrl);
+    this.api = ApiService.fromSession(sessionToken, mfaToken, baseUrl);
     this.folder = new FolderResource(this.api, this.archiveStore);
     this.record = new RecordResource(this.api, this.archiveStore);
     this.item = new ItemResource(this.folder, this.record);

--- a/src/lib/error.spec.ts
+++ b/src/lib/error.spec.ts
@@ -4,11 +4,6 @@ import { PermSdkError } from './error';
 
 const packageName = '@permanentorg/node-sdk';
 
-test('should have a generic message with the package name when not given', (t) => {
-  const error = new PermSdkError();
-  t.assert(error.message.includes(packageName));
-});
-
 test('should have the given message prefixed with the package name', (t) => {
   const message = 'my message';
   const error = new PermSdkError(message);

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,8 +1,6 @@
 export class PermSdkError extends Error {
-  constructor(message?: string, apiMessage?: string[]) {
-    if (!message && !apiMessage) {
-      super(`@permanentorg/node-sdk - error!`);
-    } else if (!apiMessage?.length) {
+  constructor(message: string, apiMessage?: string[]) {
+    if (!apiMessage?.length) {
       super(`@permanentorg/node-sdk - ${message}`);
     } else {
       super(

--- a/src/lib/oauth-client.ts
+++ b/src/lib/oauth-client.ts
@@ -1,0 +1,73 @@
+import { AuthorizationCode } from 'simple-oauth2';
+import type { AccessToken } from 'simple-oauth2';
+
+import { Permanent } from './client';
+
+class PermanentOAuthClient {
+  private client: AuthorizationCode;
+
+  public constructor(
+    clientId: string,
+    clientSecret: string,
+    private baseUrl = 'https://www.permanent.org/api',
+    authHost = 'https://auth.permanent.org/'
+  ) {
+    this.client = new AuthorizationCode({
+      client: {
+        id: clientId,
+        secret: clientSecret,
+      },
+      auth: {
+        authorizePath: '/oauth2/authorize',
+        tokenHost: authHost,
+        tokenPath: '/oauth2/token',
+      },
+    });
+  }
+
+  public authorizeUrl(
+    callbackUrl: string,
+    scope: string,
+    state: string
+  ): string {
+    // TODO: generate CSRF token and include it in state
+    // TODO: allow arbitrary state and encode it into a URL-safe value
+    return this.client.authorizeURL({
+      redirect_uri: callbackUrl,
+      scope,
+      state,
+    });
+  }
+
+  public async completeAuthorization(
+    callbackUrl: string,
+    code: string,
+    scope: string,
+    state: string
+  ): Promise<AccessToken> {
+    if (state) {
+      // TODO: verify csrf token in state
+    }
+
+    return await this.client.getToken({
+      code,
+      redirect_uri: callbackUrl,
+      scope,
+    });
+  }
+
+  public loadToken(token: string): AccessToken {
+    const tokenObject = JSON.parse(token);
+    const accessToken = this.client.createToken(tokenObject);
+    return accessToken;
+  }
+
+  public clientFromToken(accessToken: AccessToken): Permanent {
+    return new Permanent({
+      accessToken,
+      baseUrl: this.baseUrl,
+    });
+  }
+}
+
+export { PermanentOAuthClient };

--- a/src/lib/resources/folder.resource.spec.ts
+++ b/src/lib/resources/folder.resource.spec.ts
@@ -16,7 +16,7 @@ const test = anyTest as TestInterface<{
 }>;
 
 test.beforeEach((t) => {
-  const api = new ApiService('session', 'mfa', 'test');
+  const api = ApiService.fromSession('session', 'mfa', 'test');
   const archiveStore = new ArchiveStore();
 
   archiveStore.setRoot({

--- a/src/lib/resources/item.resource.spec.ts
+++ b/src/lib/resources/item.resource.spec.ts
@@ -18,7 +18,7 @@ const test = anyTest as TestInterface<{
 }>;
 
 test.beforeEach((t) => {
-  const api = new ApiService('session', 'mfa', 'test');
+  const api = ApiService.fromSession('session', 'mfa', 'test');
   const archiveStore = new ArchiveStore();
 
   archiveStore.setRoot({

--- a/src/lib/resources/record.resource.spec.ts
+++ b/src/lib/resources/record.resource.spec.ts
@@ -15,7 +15,7 @@ const test = anyTest as TestInterface<{
 }>;
 
 test.beforeEach((t) => {
-  const api = new ApiService('session', 'mfa', 'test');
+  const api = ApiService.fromSession('session', 'mfa', 'test');
   const archiveStore = new ArchiveStore();
 
   archiveStore.setRoot({

--- a/src/lib/resources/session.resource.spec.ts
+++ b/src/lib/resources/session.resource.spec.ts
@@ -15,7 +15,7 @@ const test = anyTest as TestInterface<{
 }>;
 
 test.beforeEach((t) => {
-  const api = new ApiService('session', 'mfa', 'test');
+  const api = ApiService.fromSession('session', 'mfa', 'test');
   const archiveStore = new ArchiveStore();
   t.context = {
     api,

--- a/src/lib/resources/session.resource.ts
+++ b/src/lib/resources/session.resource.ts
@@ -46,6 +46,11 @@ export class SessionResource extends BaseResource {
   }
 
   public async getAccountArchive(): Promise<ArchiveVO> {
+    const isLoggedIn = await this.isSessionValid();
+    if (!isLoggedIn) {
+      throw new PermSdkError('Credentials invalid');
+    }
+
     try {
       const response = await this.api.account.getSessionAccount();
       const account = response.Results[0].data[0].AccountVO;

--- a/src/lib/resources/share.resource.spec.ts
+++ b/src/lib/resources/share.resource.spec.ts
@@ -15,7 +15,7 @@ const test = anyTest as TestInterface<{
 }>;
 
 test.beforeEach((t) => {
-  const api = new ApiService('session', 'mfa', 'test');
+  const api = ApiService.fromSession('session', 'mfa', 'test');
   t.context = {
     api,
     share: new ShareResource(api),


### PR DESCRIPTION
Add a way for authenticating to the Permanent API via OAuth. This is critical functionality for our partners, and particularly for our Etherpad plugin.

As before, some private configuration is required: clients need an OAuth client ID and client secret, which can only be issued by Permanent. Once that's done, they can initiate an Authorization Code Grant login flow[1]. When the user returns to their application, they can then complete the flow to get an instance of the `Permanent` client that is configured with the token.

Behind the scenes, we are using simple-oauth2 (npm[2], repo[3]) to handle the OAuth workflow.

This new functionality should work alongside the legacy session-based authentication, and so should not break any existing clients.