### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",
   "repository": "https://github.com/PermanentOrg/node-sdk",
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "keywords": [],
   "scripts": {
     "build": "run-p build:*",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

docs update

- **What is the current behavior?** (You can also link to an open issue here)

The `package.json` shows a license of "MIT" but the `LICENSE` file shows AGPLv3.

- **What is the new behavior (if this is a feature change)?**

My recollection is that the license was meant to be AGPLv3, so MIT is a typo. This commit replaces "MIT" in `package.json` with the SPDX identifier for AGPLv3. Now the two license specifications match.


- **Other information**:

This bug was committed when Andrew created the repo four years ago.  Both the `package.json` and the `LICENSE` were part of the very first commit. Does that mean I win the prize for fixing the oldest bug in the codebase?




